### PR TITLE
Add table UI for webset artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000).
+
+## Webset artifact
+
+The `webset` artifact shows company and people data in a table-style interface with buttons for filtering and sorting results. Tools like `createDocument` can generate a document with `kind: "webset"` to render this panel next to the chat.

--- a/artifacts/webset/client.tsx
+++ b/artifacts/webset/client.tsx
@@ -1,0 +1,107 @@
+import { Artifact } from '@/components/create-artifact';
+import {
+  CopyIcon,
+  LineChartIcon,
+  RedoIcon,
+  SparklesIcon,
+  UndoIcon,
+} from '@/components/icons';
+import { WebsetTable } from '@/components/webset-table';
+import { parse, unparse } from 'papaparse';
+import { toast } from 'sonner';
+
+type Metadata = any;
+
+export const websetArtifact = new Artifact<'webset', Metadata>({
+  kind: 'webset',
+  description: 'Useful for exploring company and people data',
+  initialize: async () => {},
+  onStreamPart: ({ setArtifact, streamPart }) => {
+    if (streamPart.type === 'sheet-delta') {
+      setArtifact((draftArtifact) => ({
+        ...draftArtifact,
+        content: streamPart.content as string,
+        isVisible: true,
+        status: 'streaming',
+      }));
+    }
+  },
+  content: ({
+    content,
+    currentVersionIndex,
+    isCurrentVersion,
+    onSaveContent,
+    status,
+  }) => {
+    return <WebsetTable csv={content} />;
+  },
+  actions: [
+    {
+      icon: <UndoIcon size={18} />,
+      description: 'View Previous version',
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange('prev');
+      },
+      isDisabled: ({ currentVersionIndex }) => {
+        if (currentVersionIndex === 0) {
+          return true;
+        }
+
+        return false;
+      },
+    },
+    {
+      icon: <RedoIcon size={18} />,
+      description: 'View Next version',
+      onClick: ({ handleVersionChange }) => {
+        handleVersionChange('next');
+      },
+      isDisabled: ({ isCurrentVersion }) => {
+        if (isCurrentVersion) {
+          return true;
+        }
+
+        return false;
+      },
+    },
+    {
+      icon: <CopyIcon />,
+      description: 'Copy as .csv',
+      onClick: ({ content }) => {
+        const parsed = parse<string[]>(content, { skipEmptyLines: true });
+
+        const nonEmptyRows = parsed.data.filter((row) =>
+          row.some((cell) => cell.trim() !== ''),
+        );
+
+        const cleanedCsv = unparse(nonEmptyRows);
+
+        navigator.clipboard.writeText(cleanedCsv);
+        toast.success('Copied csv to clipboard!');
+      },
+    },
+  ],
+  toolbar: [
+    {
+      description: 'Format and clean data',
+      icon: <SparklesIcon />,
+      onClick: ({ appendMessage }) => {
+        appendMessage({
+          role: 'user',
+          content: 'Can you please format and clean the data?',
+        });
+      },
+    },
+    {
+      description: 'Analyze and visualize data',
+      icon: <LineChartIcon />,
+      onClick: ({ appendMessage }) => {
+        appendMessage({
+          role: 'user',
+          content:
+            'Can you please analyze and visualize the data by creating a new code artifact in python?',
+        });
+      },
+    },
+  ],
+});

--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -1,0 +1,78 @@
+import { myProvider } from '@/lib/ai/providers';
+import { websetPrompt, updateDocumentPrompt } from '@/lib/ai/prompts';
+import { createDocumentHandler } from '@/lib/artifacts/server';
+import { streamObject } from 'ai';
+import { z } from 'zod';
+
+export const websetDocumentHandler = createDocumentHandler<'webset'>({
+  kind: 'webset',
+  onCreateDocument: async ({ title, dataStream }) => {
+    let draftContent = '';
+
+    const { fullStream } = streamObject({
+      model: myProvider.languageModel('artifact-model'),
+      system: websetPrompt,
+      prompt: title,
+      schema: z.object({
+        csv: z.string().describe('CSV data'),
+      }),
+    });
+
+    for await (const delta of fullStream) {
+      const { type } = delta;
+
+      if (type === 'object') {
+        const { object } = delta;
+        const { csv } = object;
+
+        if (csv) {
+          dataStream.writeData({
+            type: 'sheet-delta',
+            content: csv,
+          });
+
+          draftContent = csv;
+        }
+      }
+    }
+
+    dataStream.writeData({
+      type: 'sheet-delta',
+      content: draftContent,
+    });
+
+    return draftContent;
+  },
+  onUpdateDocument: async ({ document, description, dataStream }) => {
+    let draftContent = '';
+
+    const { fullStream } = streamObject({
+      model: myProvider.languageModel('artifact-model'),
+      system: updateDocumentPrompt(document.content, 'webset'),
+      prompt: description,
+      schema: z.object({
+        csv: z.string(),
+      }),
+    });
+
+    for await (const delta of fullStream) {
+      const { type } = delta;
+
+      if (type === 'object') {
+        const { object } = delta;
+        const { csv } = object;
+
+        if (csv) {
+          dataStream.writeData({
+            type: 'sheet-delta',
+            content: csv,
+          });
+
+          draftContent = csv;
+        }
+      }
+    }
+
+    return draftContent;
+  },
+});

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -23,6 +23,7 @@ import { useSidebar } from './ui/sidebar';
 import { useArtifact } from '@/hooks/use-artifact';
 import { imageArtifact } from '@/artifacts/image/client';
 import { codeArtifact } from '@/artifacts/code/client';
+import { websetArtifact } from '@/artifacts/webset/client';
 import { sheetArtifact } from '@/artifacts/sheet/client';
 import { textArtifact } from '@/artifacts/text/client';
 import equal from 'fast-deep-equal';
@@ -34,6 +35,7 @@ export const artifactDefinitions = [
   codeArtifact,
   imageArtifact,
   sheetArtifact,
+  websetArtifact,
 ];
 export type ArtifactKind = (typeof artifactDefinitions)[number]['kind'];
 

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
+      {...props}
+    />
+  )
+);
+Avatar.displayName = "Avatar";
+
+const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
+  ({ className, ...props }, ref) => (
+    <img ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  )
+);
+AvatarImage.displayName = "AvatarImage";
+
+const AvatarFallback = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)}
+      {...props}
+    />
+  )
+);
+AvatarFallback.displayName = "AvatarFallback";
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+"use client";
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,47 @@
+"use client";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  )
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  )
+);
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+  )
+);
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr ref={ref} className={cn("border-b transition-colors hover:bg-muted/50", className)} {...props} />
+  )
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th ref={ref} className={cn("h-12 px-4 text-left align-middle font-medium text-muted-foreground", className)} {...props} />
+  )
+);
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn("p-4 align-middle", className)} {...props} />
+  )
+);
+TableCell.displayName = "TableCell";
+
+export { Table, TableHeader, TableBody, TableHead, TableRow, TableCell };

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -1,0 +1,131 @@
+"use client";
+import { parse } from "papaparse";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ChevronDown, Code, Filter, Maximize2, Plus, SlidersHorizontal, Zap } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+
+import { useMemo } from "react";
+
+interface WebsetTableProps {
+  csv: string;
+}
+
+export function WebsetTable({ csv }: WebsetTableProps) {
+  const { headers, rows } = useMemo(() => {
+    const parsed = parse<string[]>(csv || "", { skipEmptyLines: true });
+    const data = parsed.data as string[][];
+    const headers = data.length > 0 ? data[0] : [];
+    const rows = data.length > 1 ? data.slice(1) : [];
+    return { headers, rows };
+  }, [csv]);
+
+  return (
+    <div className="w-full bg-[#1e1a2e] text-gray-200 min-h-screen">
+      <div className="flex items-center justify-between p-4 border-b border-[#2d2640]">
+        <div className="flex items-center gap-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+          >
+            <Filter className="h-4 w-4" />
+            <span>Filter</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            <span>Sort</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+          >
+            <Code className="h-4 w-4" />
+            <span>Get Code</span>
+          </Button>
+        </div>
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+              >
+                <span>Actions</span>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="bg-[#2d2640] border-[#3d3654] text-gray-200">
+              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Export</DropdownMenuItem>
+              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Share</DropdownMenuItem>
+              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Delete</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button size="sm" className="h-8 gap-1 bg-[#8a57db] hover:bg-[#9a67eb] text-white">
+            <Zap className="h-4 w-4" />
+            <span>Add Enrichment</span>
+          </Button>
+        </div>
+      </div>
+      <div className="overflow-auto">
+        <Table className="border-collapse">
+          <TableHeader>
+            <TableRow className="border-b border-[#2d2640]">
+              <TableHead className="w-12 text-center text-gray-400 font-normal">#</TableHead>
+              {headers.map((header, idx) => (
+                <TableHead key={idx} className="min-w-[150px] text-gray-400 font-normal">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs">{header}</span>
+                  </div>
+                </TableHead>
+              ))}
+              <TableHead className="w-10">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row, rowIdx) => (
+              <TableRow key={rowIdx} className="border-b border-[#2d2640] hover:bg-[#2d2640]">
+                <TableCell className="text-center text-sm text-gray-400">{rowIdx + 1}</TableCell>
+                {row.map((cell, cellIdx) => (
+                  <TableCell key={cellIdx} className="text-gray-300">
+                    {cell}
+                  </TableCell>
+                ))}
+                <TableCell>
+                  {rowIdx === 0 && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
+                    >
+                      <Maximize2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex justify-center p-4 border-t border-[#2d2640]">
+        <Button variant="outline" className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]">
+          <span className="text-[#a57eeb]">Find more results</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -96,6 +96,10 @@ export const sheetPrompt = `
 You are a spreadsheet creation assistant. Create a spreadsheet in csv format based on the given prompt. The spreadsheet should contain meaningful column headers and data.
 `;
 
+export const websetPrompt = `
+You generate company and people information in csv format. Use the prompt to decide which fields to include.
+`;
+
 export const updateDocumentPrompt = (
   currentContent: string | null,
   type: ArtifactKind,
@@ -112,7 +116,7 @@ Improve the following code snippet based on the given prompt.
 
 ${currentContent}
 `
-      : type === 'sheet'
+      : type === 'sheet' || type === 'webset'
         ? `\
 Improve the following spreadsheet based on the given prompt.
 

--- a/lib/artifacts/server.ts
+++ b/lib/artifacts/server.ts
@@ -1,5 +1,6 @@
 import { codeDocumentHandler } from '@/artifacts/code/server';
 import { imageDocumentHandler } from '@/artifacts/image/server';
+import { websetDocumentHandler } from '@/artifacts/webset/server';
 import { sheetDocumentHandler } from '@/artifacts/sheet/server';
 import { textDocumentHandler } from '@/artifacts/text/server';
 import { ArtifactKind } from '@/components/artifact';
@@ -94,6 +95,7 @@ export const documentHandlersByArtifactKind: Array<DocumentHandler> = [
   codeDocumentHandler,
   imageDocumentHandler,
   sheetDocumentHandler,
+  websetDocumentHandler,
 ];
 
-export const artifactKinds = ['text', 'code', 'image', 'sheet'] as const;
+export const artifactKinds = ['text', 'code', 'image', 'sheet', 'webset'] as const;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -109,7 +109,7 @@ export const document = pgTable(
     createdAt: timestamp('createdAt').notNull(),
     title: text('title').notNull(),
     content: text('content'),
-    kind: varchar('text', { enum: ['text', 'code', 'image', 'sheet'] })
+    kind: varchar('text', { enum: ['text', 'code', 'image', 'sheet', 'webset'] })
       .notNull()
       .default('text'),
     userId: uuid('userId')

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './artifacts/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {

--- a/tests/routes/webset.test.ts
+++ b/tests/routes/webset.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '../fixtures';
+import { artifactKinds, documentHandlersByArtifactKind } from '@/lib/artifacts/server';
+
+// Ensure webset artifact is registered
+
+test.describe('webset artifact registration', () => {
+  test('artifactKinds includes webset', async () => {
+    expect(artifactKinds).toContain('webset');
+  });
+
+  test('document handlers include webset handler', async () => {
+    const hasWebset = documentHandlersByArtifactKind.some(h => h.kind === 'webset');
+    expect(hasWebset).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add shadcn UI components for Avatar, Badge, and Table
- implement `WebsetTable` component using provided table-style UI
- switch webset artifact to render `WebsetTable`
- update README to describe table UI for webset artifact

## Testing
- `pnpm test` *(fails: unable to download pnpm)*
- `pnpm lint` *(fails: unable to download pnpm)*