### PR TITLE
Add theme customization options

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
+import { ThemeSettings } from '@/components/theme-settings';
 
 function PureChatHeader({
   chatId,
@@ -35,6 +36,7 @@ function PureChatHeader({
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
+      <ThemeSettings />
 
       {(!open || windowWidth < 768) && (
         <Tooltip>

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -22,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from './toast';
 import { LoaderIcon } from './icons';
 import { guestRegex } from '@/lib/constants';
+import { ThemeSettings } from '@/components/theme-settings';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
@@ -32,6 +33,9 @@ export function SidebarUserNav({ user }: { user: User }) {
 
   return (
     <SidebarMenu>
+      <SidebarMenuItem>
+        <ThemeSettings />
+      </SidebarMenuItem>
       <SidebarMenuItem>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,37 @@
 'use client';
 
+import { createContext, useEffect } from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types';
 
+// Context to expose a helper for applying saved custom colors
+export const CustomThemeContext = createContext({
+  applyCustomColors: () => {},
+});
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  const applyCustomColors = () => {
+    if (typeof window === 'undefined') return;
+
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      const colors = JSON.parse(savedColors) as Record<string, string>;
+
+      Object.entries(colors).forEach(([key, value]) => {
+        if (value) {
+          document.documentElement.style.setProperty(`--${key}`, value);
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    applyCustomColors();
+  }, []);
+
+  return (
+    <CustomThemeContext.Provider value={{ applyCustomColors }}>
+      <NextThemesProvider {...props}>{children}</NextThemesProvider>
+    </CustomThemeContext.Provider>
+  );
 }

--- a/components/theme-settings.tsx
+++ b/components/theme-settings.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { Settings } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { hexToHSL } from '@/lib/color-utils';
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [customColors, setCustomColors] = useState({
+    background: '',
+    foreground: '',
+    primary: '',
+    secondary: '',
+    accent: '',
+    sidebar: '',
+  });
+
+  // Prevent hydration mismatch
+  useEffect(() => {
+    setMounted(true);
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      setCustomColors(JSON.parse(savedColors));
+    }
+  }, []);
+
+  if (!mounted) return null;
+
+  const handleColorChange = (colorKey: string, value: string) => {
+    const newColors = { ...customColors, [colorKey]: value };
+    setCustomColors(newColors);
+    localStorage.setItem('custom-theme-colors', JSON.stringify(newColors));
+    document.documentElement.style.setProperty(`--${colorKey}`, value);
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-9 w-9 rounded-md">
+          <Settings className="h-4 w-4" />
+          <span className="sr-only">Theme settings</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Theme Settings</SheetTitle>
+          <SheetDescription>
+            Customize the colors of your chat interface.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="theme-selector">Theme Mode</Label>
+            <select
+              id="theme-selector"
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2"
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="background-color">Background Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="background-color"
+                type="color"
+                value={
+                  customColors.background ||
+                  (theme === 'dark' ? '#0a0a0c' : '#ffffff')
+                }
+                onChange={(e) =>
+                  handleColorChange('background', hexToHSL(e.target.value))
+                }
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors.background ||
+                  (theme === 'dark' ? '#0a0a0c' : '#ffffff')
+                }
+                onChange={(e) =>
+                  handleColorChange('background', hexToHSL(e.target.value))
+                }
+                className="flex-1"
+                placeholder="#ffffff"
+              />
+            </div>
+          </div>
+
+          <Button
+            onClick={() => {
+              localStorage.removeItem('custom-theme-colors');
+              document.documentElement.removeAttribute('style');
+              setCustomColors({
+                background: '',
+                foreground: '',
+                primary: '',
+                secondary: '',
+                accent: '',
+                sidebar: '',
+              });
+            }}
+            variant="outline"
+            className="mt-4"
+          >
+            Reset to Default
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/lib/color-utils.ts
+++ b/lib/color-utils.ts
@@ -1,0 +1,36 @@
+// Convert hex color to HSL format for CSS variables
+export function hexToHSL(hex: string): string {
+  hex = hex.replace('#', '');
+
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  let l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h = Math.round(h * 60);
+  }
+
+  s = Math.round(s * 100);
+  l = Math.round(l * 100);
+
+  return `${h} ${s}% ${l}%`;
+}


### PR DESCRIPTION
## Summary
- add color conversion utilities
- extend ThemeProvider to load saved colors
- add a ThemeSettings sheet to tweak UI colors
- expose ThemeSettings in sidebar and chat header

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*