### PR TITLE
Add floating theme customizer

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
+import { ThemeSettings } from '@/components/theme-settings';
 
 function PureChatHeader({
   chatId,
@@ -35,6 +36,7 @@ function PureChatHeader({
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
+      <ThemeSettings />
 
       {(!open || windowWidth < 768) && (
         <Tooltip>

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -22,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from './toast';
 import { LoaderIcon } from './icons';
 import { guestRegex } from '@/lib/constants';
+import { ThemeSettings } from '@/components/theme-settings';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
@@ -32,6 +33,9 @@ export function SidebarUserNav({ user }: { user: User }) {
 
   return (
     <SidebarMenu>
+      <SidebarMenuItem>
+        <ThemeSettings />
+      </SidebarMenuItem>
       <SidebarMenuItem>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,42 @@
 'use client';
 
+import { createContext, useEffect } from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types';
+import { hexToHSL } from '@/lib/color-utils';
+
+// Context to expose a helper for applying saved custom colors
+export const CustomThemeContext = createContext({
+  applyCustomColors: () => {},
+});
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  const applyCustomColors = () => {
+    if (typeof window === 'undefined') return;
+
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      const colors = JSON.parse(savedColors) as Record<string, string>;
+
+      Object.entries(colors).forEach(([key, value]) => {
+        if (value) {
+          const cssKey = key === 'sidebar' ? 'sidebar-background' : key;
+          document.documentElement.style.setProperty(
+            `--${cssKey}`,
+            hexToHSL(value),
+          );
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    applyCustomColors();
+  }, []);
+
+  return (
+    <CustomThemeContext.Provider value={{ applyCustomColors }}>
+      <NextThemesProvider {...props}>{children}</NextThemesProvider>
+    </CustomThemeContext.Provider>
+  );
 }

--- a/components/theme-settings.tsx
+++ b/components/theme-settings.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { Settings } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { hexToHSL, hslToHex } from '@/lib/color-utils';
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [customColors, setCustomColors] = useState({
+    background: '',
+    foreground: '',
+    primary: '',
+    secondary: '',
+    accent: '',
+    sidebar: '',
+    muted: '',
+  });
+
+  // Prevent hydration mismatch
+  const getHex = (key: string) => {
+    if (typeof window === 'undefined') return '#ffffff';
+    const cssKey = key === 'sidebar' ? 'sidebar-background' : key;
+    const hsl = getComputedStyle(document.documentElement)
+      .getPropertyValue(`--${cssKey}`)
+      .trim();
+    return hslToHex(hsl);
+  };
+
+  useEffect(() => {
+    setMounted(true);
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      setCustomColors(JSON.parse(savedColors));
+    }
+  }, []);
+
+  if (!mounted) return null;
+
+  const handleColorChange = (colorKey: string, value: string) => {
+    const newColors = { ...customColors, [colorKey]: value };
+    setCustomColors(newColors);
+    localStorage.setItem('custom-theme-colors', JSON.stringify(newColors));
+
+    const cssKey = colorKey === 'sidebar' ? 'sidebar-background' : colorKey;
+    document.documentElement.style.setProperty(
+      `--${cssKey}`,
+      hexToHSL(value),
+    );
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-9 rounded-md">
+          <Settings className="size-4" />
+          <span className="sr-only">Theme settings</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Theme Settings</DialogTitle>
+          <DialogDescription>
+            Customize the colors of your chat interface.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="theme-selector">Theme Mode</Label>
+            <select
+              id="theme-selector"
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2"
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+
+          {(
+            [
+              { key: 'background', label: 'Background' },
+              { key: 'foreground', label: 'Foreground' },
+              { key: 'primary', label: 'Primary' },
+              { key: 'secondary', label: 'Secondary' },
+              { key: 'accent', label: 'Accent' },
+              { key: 'muted', label: 'Artifact Background' },
+              { key: 'sidebar', label: 'Sidebar Background' },
+            ] as const
+          ).map(({ key, label }) => (
+            <div key={key} className="grid gap-2">
+              <Label htmlFor={`${key}-color`}>{label} Color</Label>
+              <div className="flex gap-2">
+                <Input
+                  id={`${key}-color`}
+                  type="color"
+                  value={customColors[key] || getHex(key)}
+                  onChange={(e) => handleColorChange(key, e.target.value)}
+                  className="size-10 p-1"
+                />
+                <Input
+                  type="text"
+                  value={customColors[key] || getHex(key)}
+                  onChange={(e) => handleColorChange(key, e.target.value)}
+                  className="flex-1"
+                  placeholder="#ffffff"
+                />
+              </div>
+            </div>
+          ))}
+
+          <Button
+            onClick={() => {
+              localStorage.removeItem('custom-theme-colors');
+              document.documentElement.removeAttribute('style');
+              setCustomColors({
+                background: '',
+                foreground: '',
+                primary: '',
+                secondary: '',
+                accent: '',
+                sidebar: '',
+                muted: '',
+              });
+            }}
+            variant="outline"
+            className="mt-4"
+          >
+            Reset to Default
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = DialogPrimitive.Overlay;
+
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {}
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  DialogContentProps
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-transparent" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded-md border bg-background p-6 shadow-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <X className="size-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold', className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+};
+

--- a/lib/color-utils.ts
+++ b/lib/color-utils.ts
@@ -1,0 +1,91 @@
+// Convert hex color to HSL format for CSS variables
+export function hexToHSL(hex: string): string {
+  hex = hex.replace('#', '');
+
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  let l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h = Math.round(h * 60);
+  }
+
+  s = Math.round(s * 100);
+  l = Math.round(l * 100);
+
+  return `${h} ${s}% ${l}%`;
+}
+
+// Convert hsl variable value like "240 10% 3.9%" to hex
+export function hslToHex(hsl: string): string {
+  const [h, s, l] = hsl
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((v) => parseFloat(v));
+
+  const saturation = s / 100;
+  const lightness = l / 100;
+
+  const c = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lightness - c / 2;
+
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  if (0 <= h && h < 60) {
+    r = c;
+    g = x;
+  } else if (60 <= h && h < 120) {
+    r = x;
+    g = c;
+  } else if (120 <= h && h < 180) {
+    g = c;
+    b = x;
+  } else if (180 <= h && h < 240) {
+    g = x;
+    b = c;
+  } else if (240 <= h && h < 300) {
+    r = x;
+    b = c;
+  } else if (300 <= h && h < 360) {
+    r = c;
+    b = x;
+  }
+
+  r = Math.round((r + m) * 255);
+  g = Math.round((g + m) * 255);
+  b = Math.round((b + m) * 255);
+
+  return (
+    '#' +
+    [r, g, b]
+      .map((v) => {
+        const hex = v.toString(16);
+        return hex.length === 1 ? '0' + hex : hex;
+      })
+      .join('')
+  );
+}
+


### PR DESCRIPTION
## Summary
- create a reusable `Dialog` component
- allow saving custom color hex codes and apply them as HSL in `ThemeProvider`
- expand `ThemeSettings` with color pickers for key UI colors

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*