### PR TITLE
Extend theme customization

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,6 +57,11 @@
         --sidebar-accent-foreground: 258 22% 20%;
         --sidebar-border: 260 40% 90%;
         --sidebar-ring: 260 80% 60%;
+        --artifact-background: 260 43% 97%;
+        --artifact-border: 252 45% 91%;
+        --artifact-hover: 259 66% 89%;
+        --artifact-accent: 263 80% 65%;
+        --artifact-table: 260 40% 98%;
     }
     .dark {
         --background: 0 0% 0%;
@@ -91,6 +96,11 @@
         --sidebar-accent-foreground: 260 40% 95.9%;
         --sidebar-border: 260 20% 25%;
         --sidebar-ring: 260 70% 55%;
+        --artifact-background: 252 28% 14%;
+        --artifact-border: 256 25% 20%;
+        --artifact-hover: 254 22% 27%;
+        --artifact-accent: 263 65% 60%;
+        --artifact-table: 252 28% 14%;
     }
     .violet {
         --background: 270 50% 10%;
@@ -125,6 +135,11 @@
         --sidebar-accent-foreground: 270 30% 95.9%;
         --sidebar-border: 270 30% 25%;
         --sidebar-ring: 270 91.2% 69.8%;
+        --artifact-background: 270 50% 15%;
+        --artifact-border: 270 30% 25%;
+        --artifact-hover: 270 30% 25%;
+        --artifact-accent: 270 76% 60%;
+        --artifact-table: 270 50% 15%;
     }
 }
 

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
+import { ThemeSettings } from '@/components/theme-settings';
 
 function PureChatHeader({
   chatId,
@@ -35,6 +36,7 @@ function PureChatHeader({
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
+      <ThemeSettings />
 
       {(!open || windowWidth < 768) && (
         <Tooltip>

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -22,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from './toast';
 import { LoaderIcon } from './icons';
 import { guestRegex } from '@/lib/constants';
+import { ThemeSettings } from '@/components/theme-settings';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
@@ -32,6 +33,9 @@ export function SidebarUserNav({ user }: { user: User }) {
 
   return (
     <SidebarMenu>
+      <SidebarMenuItem>
+        <ThemeSettings />
+      </SidebarMenuItem>
       <SidebarMenuItem>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,38 @@
 'use client';
 
+import { createContext, useEffect } from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types';
+import { hexToHSL } from '@/lib/color-utils';
+
+// Context to expose a helper for applying saved custom colors
+export const CustomThemeContext = createContext({
+  applyCustomColors: () => {},
+});
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  const applyCustomColors = () => {
+    if (typeof window === 'undefined') return;
+
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      const colors = JSON.parse(savedColors) as Record<string, string>;
+
+      Object.entries(colors).forEach(([key, value]) => {
+        if (value) {
+          document.documentElement.style.setProperty(`--${key}`, hexToHSL(value));
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    applyCustomColors();
+  }, []);
+
+  return (
+    <CustomThemeContext.Provider value={{ applyCustomColors }}>
+      <NextThemesProvider {...props}>{children}</NextThemesProvider>
+    </CustomThemeContext.Provider>
+  );
 }

--- a/components/theme-settings.tsx
+++ b/components/theme-settings.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
+import { Settings } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { hexToHSL, hslToHex } from '@/lib/color-utils';
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [customColors, setCustomColors] = useState({
+    background: '',
+    foreground: '',
+    primary: '',
+    secondary: '',
+    accent: '',
+    'sidebar-background': '',
+    'artifact-background': '',
+    'artifact-border': '',
+    'artifact-table': '',
+  })
+
+  // Prevent hydration mismatch
+  useEffect(() => {
+    setMounted(true)
+    const savedColors = localStorage.getItem('custom-theme-colors')
+    if (savedColors) {
+      setCustomColors(JSON.parse(savedColors))
+    } else if (typeof window !== 'undefined') {
+      const computed = getComputedStyle(document.documentElement)
+      setCustomColors({
+        background: hslToHex(computed.getPropertyValue('--background').trim()),
+        foreground: hslToHex(computed.getPropertyValue('--foreground').trim()),
+        primary: hslToHex(computed.getPropertyValue('--primary').trim()),
+        secondary: hslToHex(computed.getPropertyValue('--secondary').trim()),
+        accent: hslToHex(computed.getPropertyValue('--accent').trim()),
+        'sidebar-background': hslToHex(
+          computed.getPropertyValue('--sidebar-background').trim(),
+        ),
+        'artifact-background': hslToHex(
+          computed.getPropertyValue('--artifact-background').trim(),
+        ),
+        'artifact-border': hslToHex(
+          computed.getPropertyValue('--artifact-border').trim(),
+        ),
+        'artifact-table': hslToHex(
+          computed.getPropertyValue('--artifact-table').trim(),
+        ),
+      })
+    }
+  }, [])
+
+  if (!mounted) return null;
+
+  const handleColorChange = (colorKey: string, hex: string) => {
+    const newColors = { ...customColors, [colorKey]: hex }
+    setCustomColors(newColors)
+    localStorage.setItem('custom-theme-colors', JSON.stringify(newColors))
+    document.documentElement.style.setProperty(`--${colorKey}`, hexToHSL(hex))
+  }
+
+  const fields = [
+    { key: 'background', label: 'Background' },
+    { key: 'foreground', label: 'Foreground' },
+    { key: 'primary', label: 'Primary' },
+    { key: 'secondary', label: 'Secondary' },
+    { key: 'accent', label: 'Accent' },
+    { key: 'sidebar-background', label: 'Sidebar Background' },
+    { key: 'artifact-background', label: 'Artifact Background' },
+    { key: 'artifact-border', label: 'Artifact Border' },
+    { key: 'artifact-table', label: 'Artifact Table' },
+  ] as const
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-8 w-8 rounded-md">
+          <Settings className="h-4 w-4" />
+          <span className="sr-only">Theme settings</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Theme Settings</DialogTitle>
+          <DialogDescription>
+            Customize the colors of your chat interface.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="theme-selector">Theme Mode</Label>
+            <select
+              id="theme-selector"
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2"
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+
+          {fields.map(({ key, label }) => (
+            <div className="grid gap-2" key={key}>
+              <Label htmlFor={`${key}-color`}>{label} Color</Label>
+              <div className="flex gap-2">
+                <Input
+                  id={`${key}-color`}
+                  type="color"
+                  value={customColors[key as keyof typeof customColors] || '#ffffff'}
+                  onChange={(e) => handleColorChange(key, e.target.value)}
+                  className="w-12 h-10 p-1"
+                />
+                <Input
+                  type="text"
+                  value={customColors[key as keyof typeof customColors] || '#ffffff'}
+                  onChange={(e) => handleColorChange(key, e.target.value)}
+                  className="flex-1"
+                  placeholder="#ffffff"
+                />
+              </div>
+            </div>
+          ))}
+
+          <Button
+            onClick={() => {
+              localStorage.removeItem('custom-theme-colors');
+              document.documentElement.removeAttribute('style');
+              setCustomColors({
+                background: '',
+                foreground: '',
+                primary: '',
+                secondary: '',
+                accent: '',
+                'sidebar-background': '',
+                'artifact-background': '',
+                'artifact-border': '',
+                'artifact-table': '',
+              });
+            }}
+            variant="outline"
+            className="mt-4"
+          >
+            Reset to Default
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-transparent', className)}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-4 top-4 z-50 grid w-64 gap-4 rounded-md border bg-background p-4 shadow-lg focus:outline-none',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className='absolute right-2 top-2 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none'>
+        <X className='h-4 w-4' />
+        <span className='sr-only'>Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold text-foreground', className)} {...props} />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -61,26 +61,26 @@ export function WebsetTable({ csv }: WebsetTableProps) {
   }, [filteredRows, headers, sortedColumn, sortDirection]);
 
   return (
-    <div className="w-full bg-[#1e1a2e] text-gray-200 min-h-screen">
-      <div className="flex items-center justify-between p-4 border-b border-[#2d2640]">
+    <div className="w-full bg-[hsl(var(--artifact-background))] text-gray-200 min-h-screen">
+      <div className="flex items-center justify-between p-4 border-b border-[hsl(var(--artifact-border))]">
         <div className="flex items-center gap-4">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
                 size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+                className="h-8 gap-1 bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] text-gray-300 hover:bg-[hsl(var(--artifact-hover))] hover:text-white"
               >
                 <Filter className="h-4 w-4" />
                 <span>Filter</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="bg-[#2d2640] border-[#3d3654] p-2 space-y-2">
+            <DropdownMenuContent className="bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] p-2 space-y-2">
               {headers.map((header) => (
                 <div key={header} className="flex items-center gap-2">
                   <span className="w-32 text-xs">{header}</span>
                   <input
-                    className="flex-1 rounded bg-[#1e1a2e] border border-[#3d3654] px-2 py-1 text-xs"
+                    className="flex-1 rounded bg-[hsl(var(--artifact-background))] border border-[hsl(var(--artifact-hover))] px-2 py-1 text-xs"
                     placeholder="Filter"
                     value={filters[header] || ''}
                     onChange={(e) =>
@@ -96,18 +96,18 @@ export function WebsetTable({ csv }: WebsetTableProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+                className="h-8 gap-1 bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] text-gray-300 hover:bg-[hsl(var(--artifact-hover))] hover:text-white"
               >
                 <SlidersHorizontal className="h-4 w-4" />
                 <span>Sort</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="bg-[#2d2640] border-[#3d3654]">
+            <DropdownMenuContent className="bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))]">
               {headers.map((header) => (
                 <DropdownMenuItem
                   key={header}
                   onSelect={() => setSortedColumn(header)}
-                  className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
+                  className="cursor-pointer hover:bg-[hsl(var(--artifact-hover))] focus:bg-[hsl(var(--artifact-hover))]"
                 >
                   {header}
                 </DropdownMenuItem>
@@ -116,7 +116,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                 onSelect={() =>
                   setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
                 }
-                className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
+                className="cursor-pointer hover:bg-[hsl(var(--artifact-hover))] focus:bg-[hsl(var(--artifact-hover))]"
               >
                 Direction: {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
               </DropdownMenuItem>
@@ -125,7 +125,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           <Button
             variant="outline"
             size="sm"
-            className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+            className="h-8 gap-1 bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] text-gray-300 hover:bg-[hsl(var(--artifact-hover))] hover:text-white"
           >
             <Code className="h-4 w-4" />
             <span>Get Code</span>
@@ -137,19 +137,19 @@ export function WebsetTable({ csv }: WebsetTableProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
+                className="h-8 gap-1 bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] text-gray-300 hover:bg-[hsl(var(--artifact-hover))] hover:text-white"
               >
                 <span>Actions</span>
                 <ChevronDown className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="bg-[#2d2640] border-[#3d3654] text-gray-200">
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Export</DropdownMenuItem>
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Share</DropdownMenuItem>
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Delete</DropdownMenuItem>
+            <DropdownMenuContent align="end" className="bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] text-gray-200">
+              <DropdownMenuItem className="hover:bg-[hsl(var(--artifact-hover))] focus:bg-[hsl(var(--artifact-hover))]">Export</DropdownMenuItem>
+              <DropdownMenuItem className="hover:bg-[hsl(var(--artifact-hover))] focus:bg-[hsl(var(--artifact-hover))]">Share</DropdownMenuItem>
+              <DropdownMenuItem className="hover:bg-[hsl(var(--artifact-hover))] focus:bg-[hsl(var(--artifact-hover))]">Delete</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button size="sm" className="h-8 gap-1 bg-[#8a57db] hover:bg-[#9a67eb] text-white">
+          <Button size="sm" className="h-8 gap-1 bg-[hsl(var(--artifact-accent))] hover:bg-[hsl(var(--artifact-accent))] text-white">
             <Zap className="h-4 w-4" />
             <span>Add Enrichment</span>
           </Button>
@@ -158,7 +158,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
       <div className="overflow-auto">
         <Table className="border-collapse">
           <TableHeader>
-            <TableRow className="border-b border-[#2d2640]">
+            <TableRow className="border-b border-[hsl(var(--artifact-border))]">
               <TableHead className="w-12 text-center text-gray-400 font-normal">#</TableHead>
               {headers.map((header, idx) => (
                 <TableHead key={idx} className="min-w-[150px] text-gray-400 font-normal">
@@ -171,7 +171,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
+                  className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[hsl(var(--artifact-hover))]"
                 >
                   <Plus className="h-4 w-4" />
                 </Button>
@@ -180,7 +180,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           </TableHeader>
           <TableBody>
             {sortedRows.map((row, rowIdx) => (
-              <TableRow key={rowIdx} className="border-b border-[#2d2640] hover:bg-[#2d2640]">
+              <TableRow key={rowIdx} className="border-b border-[hsl(var(--artifact-border))] hover:bg-[hsl(var(--artifact-table))]">
                 <TableCell className="text-center text-sm text-gray-400">{rowIdx + 1}</TableCell>
                 {row.map((cell, cellIdx) => {
                   const header = headers[cellIdx] || '';
@@ -228,7 +228,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
+                      className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[hsl(var(--artifact-hover))]"
                     >
                       <Maximize2 className="h-4 w-4" />
                     </Button>
@@ -239,9 +239,9 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           </TableBody>
         </Table>
       </div>
-      <div className="flex justify-center p-4 border-t border-[#2d2640]">
-        <Button variant="outline" className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]">
-          <span className="text-[#a57eeb]">Find more results</span>
+      <div className="flex justify-center p-4 border-t border-[hsl(var(--artifact-border))]">
+        <Button variant="outline" className="rounded-full px-6 bg-[hsl(var(--artifact-border))] border-[hsl(var(--artifact-hover))] hover:bg-[hsl(var(--artifact-hover))]">
+          <span className="text-[hsl(var(--artifact-accent))]">Find more results</span>
         </Button>
       </div>
     </div>

--- a/lib/color-utils.ts
+++ b/lib/color-utils.ts
@@ -1,0 +1,66 @@
+// Convert hex color to HSL format for CSS variables
+export function hexToHSL(hex: string): string {
+  hex = hex.replace('#', '')
+  const r = parseInt(hex.substring(0, 2), 16) / 255
+  const g = parseInt(hex.substring(2, 4), 16) / 255
+  const b = parseInt(hex.substring(4, 6), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  let l = (max + min) / 2
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+    }
+    h = Math.round(h * 60)
+  }
+  s = Math.round(s * 100)
+  l = Math.round(l * 100)
+  return `${h} ${s}% ${l}%`
+}
+
+export function hslToHex(hsl: string): string {
+  const [h, sPart, lPart] = hsl.split(/\s+/)
+  const s = parseFloat(sPart) / 100
+  const l = parseFloat(lPart) / 100
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hh = parseFloat(h) / 60
+  const x = c * (1 - Math.abs((hh % 2) - 1))
+  let r = 0, g = 0, b = 0
+  if (hh >= 0 && hh < 1) {
+    r = c
+    g = x
+  } else if (hh >= 1 && hh < 2) {
+    r = x
+    g = c
+  } else if (hh >= 2 && hh < 3) {
+    g = c
+    b = x
+  } else if (hh >= 3 && hh < 4) {
+    g = x
+    b = c
+  } else if (hh >= 4 && hh < 5) {
+    r = x
+    b = c
+  } else if (hh >= 5 && hh < 6) {
+    r = c
+    b = x
+  }
+  const m = l - c / 2
+  const toHex = (v: number) => {
+    const hex = Math.round((v + m) * 255).toString(16).padStart(2, '0')
+    return hex
+  }
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}


### PR DESCRIPTION
## Summary
- add floating `Dialog` component for overlay-free windows
- convert color utilities and theme provider to use hex values
- update global CSS with artifact color variables
- make the webset table use theme variables
- overhaul ThemeSettings to support customizing all colors

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*