### PR TITLE
Add theme color customization and draggable settings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,6 +57,8 @@
         --sidebar-accent-foreground: 258 22% 20%;
         --sidebar-border: 260 40% 90%;
         --sidebar-ring: 260 80% 60%;
+        --artifact-background: 252 28% 14%;
+        --artifact-heading: 263 65% 60%;
     }
     .dark {
         --background: 0 0% 0%;
@@ -91,6 +93,8 @@
         --sidebar-accent-foreground: 260 40% 95.9%;
         --sidebar-border: 260 20% 25%;
         --sidebar-ring: 260 70% 55%;
+        --artifact-background: 252 28% 14%;
+        --artifact-heading: 263 65% 60%;
     }
     .violet {
         --background: 270 50% 10%;
@@ -125,6 +129,8 @@
         --sidebar-accent-foreground: 270 30% 95.9%;
         --sidebar-border: 270 30% 25%;
         --sidebar-ring: 270 91.2% 69.8%;
+        --artifact-background: 252 28% 14%;
+        --artifact-heading: 263 65% 60%;
     }
 }
 

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
+import { ThemeSettings } from '@/components/theme-settings';
 
 function PureChatHeader({
   chatId,
@@ -35,6 +36,7 @@ function PureChatHeader({
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
+      <ThemeSettings />
 
       {(!open || windowWidth < 768) && (
         <Tooltip>

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -22,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from './toast';
 import { LoaderIcon } from './icons';
 import { guestRegex } from '@/lib/constants';
+import { ThemeSettings } from '@/components/theme-settings';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
@@ -32,6 +33,9 @@ export function SidebarUserNav({ user }: { user: User }) {
 
   return (
     <SidebarMenu>
+      <SidebarMenuItem>
+        <ThemeSettings />
+      </SidebarMenuItem>
       <SidebarMenuItem>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,38 @@
 'use client';
 
+import { createContext, useEffect } from 'react';
+import { hexToHSL } from '@/lib/color-utils';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types';
 
+// Context to expose a helper for applying saved custom colors
+export const CustomThemeContext = createContext({
+  applyCustomColors: () => {},
+});
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  const applyCustomColors = () => {
+    if (typeof window === 'undefined') return;
+
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      const colors = JSON.parse(savedColors) as Record<string, string>;
+
+      Object.entries(colors).forEach(([key, hex]) => {
+        if (hex) {
+          document.documentElement.style.setProperty(`--${key}`, hexToHSL(hex));
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    applyCustomColors();
+  }, []);
+
+  return (
+    <CustomThemeContext.Provider value={{ applyCustomColors }}>
+      <NextThemesProvider {...props}>{children}</NextThemesProvider>
+    </CustomThemeContext.Provider>
+  );
 }

--- a/components/theme-settings.tsx
+++ b/components/theme-settings.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { Settings } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { hexToHSL, hslToHex } from '@/lib/color-utils';
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [customColors, setCustomColors] = useState<Record<string, string>>({
+    background: '',
+    foreground: '',
+    primary: '',
+    secondary: '',
+    accent: '',
+    'sidebar-background': '',
+    'artifact-background': '',
+    'artifact-heading': '',
+  });
+
+  // Prevent hydration mismatch
+  useEffect(() => {
+    setMounted(true);
+    const savedColors = localStorage.getItem('custom-theme-colors');
+    if (savedColors) {
+      setCustomColors(JSON.parse(savedColors));
+    }
+  }, []);
+
+  const getDefaultHex = (name: string, fallback: string) => {
+    if (!mounted) return fallback;
+    const hsl = getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();
+    return hsl ? hslToHex(hsl) : fallback;
+  };
+
+  if (!mounted) return null;
+
+  const handleColorChange = (colorKey: string, hex: string) => {
+    const newColors = { ...customColors, [colorKey]: hex };
+    setCustomColors(newColors);
+    localStorage.setItem('custom-theme-colors', JSON.stringify(newColors));
+    document.documentElement.style.setProperty(`--${colorKey}`, hexToHSL(hex));
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-9 w-9 rounded-md">
+          <Settings className="h-4 w-4" />
+          <span className="sr-only">Theme settings</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <div className="space-y-2 pb-2">
+          <h2 className="text-lg font-semibold">Theme Settings</h2>
+          <p className="text-sm text-muted-foreground">
+            Customize the colors of your chat interface.
+          </p>
+        </div>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="theme-selector">Theme Mode</Label>
+            <select
+              id="theme-selector"
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2"
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="background-color">Background Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="background-color"
+                type="color"
+                value={
+                  customColors.background ||
+                  getDefaultHex('background', theme === 'dark' ? '#0a0a0c' : '#ffffff')
+                }
+                onChange={(e) => handleColorChange('background', e.target.value)}
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors.background ||
+                  getDefaultHex('background', theme === 'dark' ? '#0a0a0c' : '#ffffff')
+                }
+                onChange={(e) => handleColorChange('background', e.target.value)}
+                className="flex-1"
+                placeholder="#ffffff"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="foreground-color">Foreground Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="foreground-color"
+                type="color"
+                value={
+                  customColors['foreground'] ||
+                  getDefaultHex('foreground', '#000000')
+                }
+                onChange={(e) => handleColorChange('foreground', e.target.value)}
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['foreground'] ||
+                  getDefaultHex('foreground', '#000000')
+                }
+                onChange={(e) => handleColorChange('foreground', e.target.value)}
+                className="flex-1"
+                placeholder="#000000"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="primary-color">Primary Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="primary-color"
+                type="color"
+                value={
+                  customColors['primary'] ||
+                  getDefaultHex('primary', '#0000ff')
+                }
+                onChange={(e) => handleColorChange('primary', e.target.value)}
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['primary'] ||
+                  getDefaultHex('primary', '#0000ff')
+                }
+                onChange={(e) => handleColorChange('primary', e.target.value)}
+                className="flex-1"
+                placeholder="#0000ff"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="secondary-color">Secondary Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="secondary-color"
+                type="color"
+                value={
+                  customColors['secondary'] ||
+                  getDefaultHex('secondary', '#dddddd')
+                }
+                onChange={(e) => handleColorChange('secondary', e.target.value)}
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['secondary'] ||
+                  getDefaultHex('secondary', '#dddddd')
+                }
+                onChange={(e) => handleColorChange('secondary', e.target.value)}
+                className="flex-1"
+                placeholder="#dddddd"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="accent-color">Accent Color</Label>
+            <div className="flex gap-2">
+              <Input
+                id="accent-color"
+                type="color"
+                value={
+                  customColors['accent'] ||
+                  getDefaultHex('accent', '#888888')
+                }
+                onChange={(e) => handleColorChange('accent', e.target.value)}
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['accent'] ||
+                  getDefaultHex('accent', '#888888')
+                }
+                onChange={(e) => handleColorChange('accent', e.target.value)}
+                className="flex-1"
+                placeholder="#888888"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="sidebar-color">Sidebar Background</Label>
+            <div className="flex gap-2">
+              <Input
+                id="sidebar-color"
+                type="color"
+                value={
+                  customColors['sidebar-background'] ||
+                  getDefaultHex('sidebar-background', '#f0f0f0')
+                }
+                onChange={(e) =>
+                  handleColorChange('sidebar-background', e.target.value)
+                }
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['sidebar-background'] ||
+                  getDefaultHex('sidebar-background', '#f0f0f0')
+                }
+                onChange={(e) =>
+                  handleColorChange('sidebar-background', e.target.value)
+                }
+                className="flex-1"
+                placeholder="#f0f0f0"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="artifact-bg-color">Artifact Background</Label>
+            <div className="flex gap-2">
+              <Input
+                id="artifact-bg-color"
+                type="color"
+                value={
+                  customColors['artifact-background'] ||
+                  getDefaultHex('artifact-background', '#1e1a2e')
+                }
+                onChange={(e) =>
+                  handleColorChange('artifact-background', e.target.value)
+                }
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['artifact-background'] ||
+                  getDefaultHex('artifact-background', '#1e1a2e')
+                }
+                onChange={(e) =>
+                  handleColorChange('artifact-background', e.target.value)
+                }
+                className="flex-1"
+                placeholder="#1e1a2e"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="artifact-head-color">Artifact Heading</Label>
+            <div className="flex gap-2">
+              <Input
+                id="artifact-head-color"
+                type="color"
+                value={
+                  customColors['artifact-heading'] ||
+                  getDefaultHex('artifact-heading', '#8a57db')
+                }
+                onChange={(e) =>
+                  handleColorChange('artifact-heading', e.target.value)
+                }
+                className="w-12 h-10 p-1"
+              />
+              <Input
+                type="text"
+                value={
+                  customColors['artifact-heading'] ||
+                  getDefaultHex('artifact-heading', '#8a57db')
+                }
+                onChange={(e) =>
+                  handleColorChange('artifact-heading', e.target.value)
+                }
+                className="flex-1"
+                placeholder="#8a57db"
+              />
+            </div>
+          </div>
+
+          <Button
+            onClick={() => {
+              localStorage.removeItem('custom-theme-colors');
+              document.documentElement.removeAttribute('style');
+              setCustomColors({
+                background: '',
+                foreground: '',
+                primary: '',
+                secondary: '',
+                accent: '',
+                'sidebar-background': '',
+                'artifact-background': '',
+                'artifact-heading': '',
+              });
+            }}
+            variant="outline"
+            className="mt-4"
+          >
+            Reset to Default
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-transparent', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {}
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  DialogContentProps
+>(({ className, children, ...props }, ref) => {
+  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+  const dragOffset = React.useRef<{ x: number; y: number } | null>(null);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragOffset.current = { x: e.clientX - position.x, y: e.clientY - position.y };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragOffset.current) return;
+    setPosition({ x: e.clientX - dragOffset.current.x, y: e.clientY - dragOffset.current.y });
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragOffset.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  };
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        style={{ transform: `translate3d(${position.x}px, ${position.y}px, 0)` }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded-md border bg-background p-4 shadow-lg focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-2 top-2 rounded-sm opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogTrigger, DialogContent };

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -61,7 +61,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
   }, [filteredRows, headers, sortedColumn, sortDirection]);
 
   return (
-    <div className="w-full bg-[#1e1a2e] text-gray-200 min-h-screen">
+    <div className="w-full bg-[hsl(var(--artifact-background))] text-gray-200 min-h-screen">
       <div className="flex items-center justify-between p-4 border-b border-[#2d2640]">
         <div className="flex items-center gap-4">
           <DropdownMenu>
@@ -149,7 +149,10 @@ export function WebsetTable({ csv }: WebsetTableProps) {
               <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Delete</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button size="sm" className="h-8 gap-1 bg-[#8a57db] hover:bg-[#9a67eb] text-white">
+          <Button
+            size="sm"
+            className="h-8 gap-1 text-white bg-[hsl(var(--artifact-heading))] hover:brightness-110"
+          >
             <Zap className="h-4 w-4" />
             <span>Add Enrichment</span>
           </Button>
@@ -241,7 +244,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
       </div>
       <div className="flex justify-center p-4 border-t border-[#2d2640]">
         <Button variant="outline" className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]">
-          <span className="text-[#a57eeb]">Find more results</span>
+          <span className="text-[hsl(var(--artifact-heading))]">Find more results</span>
         </Button>
       </div>
     </div>

--- a/lib/color-utils.ts
+++ b/lib/color-utils.ts
@@ -1,0 +1,79 @@
+// Convert hex color to HSL format for CSS variables
+export function hexToHSL(hex: string): string {
+  hex = hex.replace('#', '');
+
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  let l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h = Math.round(h * 60);
+  }
+
+  s = Math.round(s * 100);
+  l = Math.round(l * 100);
+
+  return `${h} ${s}% ${l}%`;
+}
+
+// Convert HSL color ("h s% l%") to hex format
+export function hslToHex(hsl: string): string {
+  const [hStr, sStr, lStr] = hsl
+    .replace(/[hsl()]/g, '')
+    .trim()
+    .split(/\s+/);
+  const h = parseFloat(hStr);
+  const s = parseFloat(sStr) / 100;
+  const l = parseFloat(lStr) / 100;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+
+  const toHex = (v: number) => Math.round((v + m) * 255).toString(16).padStart(2, '0');
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}


### PR DESCRIPTION
## Summary
- add draggable dialog component
- allow editing theme and artifact colors
- persist custom colors as hex and convert to HSL on load
- expose artifact heading and background variables
- update webset table to use theme variables

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*