### PR TITLE
Add webset metadata and toolbar actions

### DIFF
--- a/artifacts/webset/client.tsx
+++ b/artifacts/webset/client.tsx
@@ -2,20 +2,32 @@ import { Artifact } from '@/components/create-artifact';
 import {
   CopyIcon,
   LineChartIcon,
+  PlusIcon,
   RedoIcon,
   SparklesIcon,
   UndoIcon,
+  CodeIcon,
 } from '@/components/icons';
 import { WebsetTable } from '@/components/webset-table';
 import { parse, unparse } from 'papaparse';
 import { toast } from 'sonner';
 
-type Metadata = any;
+export interface WebsetMetadata {
+  filters: Record<string, string>;
+  sortedColumn: string | null;
+  sortDirection: 'asc' | 'desc';
+}
 
-export const websetArtifact = new Artifact<'webset', Metadata>({
+export const websetArtifact = new Artifact<'webset', WebsetMetadata>({
   kind: 'webset',
   description: 'Useful for exploring company and people data',
-  initialize: async () => {},
+  initialize: async ({ setMetadata }) => {
+    setMetadata({
+      filters: {},
+      sortedColumn: null,
+      sortDirection: 'asc',
+    });
+  },
   onStreamPart: ({ setArtifact, streamPart }) => {
     if (streamPart.type === 'sheet-delta') {
       setArtifact((draftArtifact) => ({
@@ -26,14 +38,24 @@ export const websetArtifact = new Artifact<'webset', Metadata>({
       }));
     }
   },
-  content: ({
-    content,
-    currentVersionIndex,
-    isCurrentVersion,
-    onSaveContent,
-    status,
-  }) => {
-    return <WebsetTable csv={content} />;
+  content: ({ content, metadata, setMetadata }) => {
+    return (
+      <WebsetTable
+        csv={content}
+        filters={metadata?.filters || {}}
+        sortedColumn={metadata?.sortedColumn || null}
+        sortDirection={metadata?.sortDirection || 'asc'}
+        onFiltersChange={(filters) =>
+          setMetadata((m) => ({ ...m, filters }))
+        }
+        onSortedColumnChange={(column) =>
+          setMetadata((m) => ({ ...m, sortedColumn: column }))
+        }
+        onSortDirectionChange={(direction) =>
+          setMetadata((m) => ({ ...m, sortDirection: direction }))
+        }
+      />
+    );
   },
   actions: [
     {
@@ -100,6 +122,26 @@ export const websetArtifact = new Artifact<'webset', Metadata>({
           role: 'user',
           content:
             'Can you please analyze and visualize the data by creating a new code artifact in python?',
+        });
+      },
+    },
+    {
+      description: 'Get code',
+      icon: <CodeIcon />,
+      onClick: ({ appendMessage }) => {
+        appendMessage({
+          role: 'user',
+          content: 'Generate code to reproduce this webset.',
+        });
+      },
+    },
+    {
+      description: 'Add enrichment',
+      icon: <PlusIcon />,
+      onClick: ({ appendMessage }) => {
+        appendMessage({
+          role: 'user',
+          content: 'Please add enrichment to this webset.',
         });
       },
     },

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -5,15 +5,29 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { ChevronDown, Code, Filter, Maximize2, Plus, SlidersHorizontal, Zap } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface WebsetTableProps {
   csv: string;
+  filters: Record<string, string>;
+  sortedColumn: string | null;
+  sortDirection: 'asc' | 'desc';
+  onFiltersChange: (filters: Record<string, string>) => void;
+  onSortedColumnChange: (column: string | null) => void;
+  onSortDirectionChange: (direction: 'asc' | 'desc') => void;
 }
 
-export function WebsetTable({ csv }: WebsetTableProps) {
+export function WebsetTable({
+  csv,
+  filters,
+  sortedColumn,
+  sortDirection,
+  onFiltersChange,
+  onSortedColumnChange,
+  onSortDirectionChange,
+}: WebsetTableProps) {
   const { headers, rows } = useMemo(() => {
     const parsed = parse<string[]>(csv || "", { skipEmptyLines: true });
     const data = parsed.data as string[][];
@@ -22,9 +36,6 @@ export function WebsetTable({ csv }: WebsetTableProps) {
     return { headers, rows };
   }, [csv]);
 
-  const [filters, setFilters] = useState<Record<string, string>>({});
-  const [sortedColumn, setSortedColumn] = useState<string | null>(null);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
   const filteredRows = useMemo(() => {
     return rows.filter((row) =>
@@ -84,7 +95,10 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                     placeholder="Filter"
                     value={filters[header] || ''}
                     onChange={(e) =>
-                      setFilters({ ...filters, [header]: e.target.value })
+                      onFiltersChange({
+                        ...filters,
+                        [header]: e.target.value,
+                      })
                     }
                   />
                 </div>
@@ -106,7 +120,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
               {headers.map((header) => (
                 <DropdownMenuItem
                   key={header}
-                  onSelect={() => setSortedColumn(header)}
+                  onSelect={() => onSortedColumnChange(header)}
                   className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
                 >
                   {header}
@@ -114,7 +128,9 @@ export function WebsetTable({ csv }: WebsetTableProps) {
               ))}
               <DropdownMenuItem
                 onSelect={() =>
-                  setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+                  onSortDirectionChange(
+                    sortDirection === 'asc' ? 'desc' : 'asc',
+                  )
                 }
                 className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
               >

--- a/tests/routes/webset.test.ts
+++ b/tests/routes/webset.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../fixtures';
 import { artifactKinds, documentHandlersByArtifactKind } from '@/lib/artifacts/server';
+import { websetArtifact } from '@/artifacts/webset/client';
 
 // Ensure webset artifact is registered
 
@@ -11,5 +12,11 @@ test.describe('webset artifact registration', () => {
   test('document handlers include webset handler', async () => {
     const hasWebset = documentHandlersByArtifactKind.some(h => h.kind === 'webset');
     expect(hasWebset).toBeTruthy();
+  });
+
+  test('toolbar includes new actions', async () => {
+    const descriptions = websetArtifact.toolbar.map((t) => t.description);
+    expect(descriptions).toContain('Get code');
+    expect(descriptions).toContain('Add enrichment');
   });
 });


### PR DESCRIPTION
## Summary
- introduce `WebsetMetadata` interface and default metadata
- allow external control of filters and sorting in `<WebsetTable>`
- pass metadata between webset artifact and table
- add toolbar buttons for "Get code" and "Add enrichment"
- test toolbar items are registered

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*
- `pnpm test` *(fails: EHOSTUNREACH during pnpm installation)*