### PR TITLE
Integrate profile card artifact

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -23,6 +23,7 @@ import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
+import { getProfiles } from '@/lib/ai/tools/get-profiles';
 import { isProductionEnvironment } from '@/lib/constants';
 import { myProvider } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
@@ -156,6 +157,7 @@ export async function POST(request: Request) {
               ? []
               : [
                   'getWeather',
+                  'getProfiles',
                   'createDocument',
                   'updateDocument',
                   'requestSuggestions',
@@ -164,6 +166,7 @@ export async function POST(request: Request) {
           experimental_generateMessageId: generateUUID,
           tools: {
             getWeather,
+            getProfiles: getProfiles({ session, dataStream }),
             createDocument: createDocument({ session, dataStream }),
             updateDocument: updateDocument({ session, dataStream }),
             requestSuggestions: requestSuggestions({

--- a/artifacts/profile-card/client.tsx
+++ b/artifacts/profile-card/client.tsx
@@ -1,0 +1,23 @@
+import ProfileCard, { ProfileCardProps } from '@/components/ProfileCard';
+import { Artifact } from '@/components/create-artifact';
+
+export const profileCardArtifact = new Artifact<'profile_card', ProfileCardProps>({
+  kind: 'profile_card',
+  description: 'Profile card display',
+  initialize: async () => {},
+  onStreamPart: ({ streamPart, setArtifact, setMetadata }) => {
+    if (streamPart.type === 'profile-card-delta') {
+      try {
+        const data = JSON.parse(streamPart.content as string) as ProfileCardProps;
+        setMetadata(data);
+        setArtifact((draft) => ({ ...draft, isVisible: true, status: 'streaming' }));
+      } catch {}
+    }
+  },
+  content: ({ metadata }) => {
+    if (!metadata) return null;
+    return <ProfileCard {...metadata} />;
+  },
+  actions: [],
+  toolbar: [],
+});

--- a/artifacts/profile-card/server.ts
+++ b/artifacts/profile-card/server.ts
@@ -1,0 +1,24 @@
+import { createDocumentHandler } from '@/lib/artifacts/server';
+
+export const profileCardDocumentHandler = createDocumentHandler<'profile_card'>({
+  kind: 'profile_card',
+  onCreateDocument: async ({ title, dataStream }) => {
+    const data = {
+      name: title,
+      title: '',
+      company: '',
+    };
+    dataStream.writeData({
+      type: 'profile-card-delta',
+      content: JSON.stringify(data),
+    });
+    return JSON.stringify(data);
+  },
+  onUpdateDocument: async ({ document, dataStream }) => {
+    dataStream.writeData({
+      type: 'profile-card-delta',
+      content: document.content ?? '',
+    });
+    return document.content ?? '';
+  },
+});

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { motion } from 'framer-motion';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+
+export interface ProfileCardProps {
+  name: string;
+  title?: string;
+  company?: string;
+  email?: string;
+  matchScore?: number;
+  imageUrl?: string;
+  query?: string;
+}
+
+function toCsv(profile: ProfileCardProps) {
+  const headers = ['name', 'title', 'company', 'email'];
+  const rows = [
+    [profile.name, profile.title ?? '', profile.company ?? '', profile.email ?? ''],
+  ];
+  const csv = [headers.join(','), rows.map((r) => r.join(',')).join('\n')].join('\n');
+  return csv;
+}
+
+export default function ProfileCard({
+  name,
+  title,
+  company,
+  email,
+  matchScore,
+  imageUrl,
+  query,
+}: ProfileCardProps) {
+  const handleExport = () => {
+    const csv = toCsv({ name, title, company, email });
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    window.open(url);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const initials = name
+    .split(' ')
+    .map((p) => p.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 50 }}
+      animate={{ opacity: 1, x: 0 }}
+      className="p-4"
+    >
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="flex flex-row items-center gap-4">
+          <Avatar>
+            {imageUrl && <AvatarImage src={imageUrl} alt={name} />}
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1">
+            <CardTitle>{name}</CardTitle>
+            {(title || company) && (
+              <CardDescription>
+                {title}
+                {title && company ? ', ' : ''}
+                {company}
+              </CardDescription>
+            )}
+            {query && (
+              <p className="text-xs text-muted-foreground mt-1">Query: {query}</p>
+            )}
+          </div>
+          {typeof matchScore === 'number' && (
+            <Badge variant="secondary" className="self-start">
+              {Math.round(matchScore * 100)}%
+            </Badge>
+          )}
+        </CardHeader>
+        <CardContent></CardContent>
+        <CardFooter className="justify-end space-x-2">
+          <Button size="sm" variant="outline" onClick={handleExport}>
+            Export CSV
+          </Button>
+          {email && (
+            <Button size="sm" onClick={() => (window.location.href = `mailto:${email}`)}>
+              Contact
+            </Button>
+          )}
+        </CardFooter>
+      </Card>
+    </motion.div>
+  );
+}

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -26,6 +26,7 @@ import { codeArtifact } from '@/artifacts/code/client';
 import { websetArtifact } from '@/artifacts/webset/client';
 import { sheetArtifact } from '@/artifacts/sheet/client';
 import { textArtifact } from '@/artifacts/text/client';
+import { profileCardArtifact } from '@/artifacts/profile-card/client';
 import equal from 'fast-deep-equal';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { VisibilityType } from './visibility-selector';
@@ -36,6 +37,7 @@ export const artifactDefinitions = [
   imageArtifact,
   sheetArtifact,
   websetArtifact,
+  profileCardArtifact,
 ];
 export type ArtifactKind = (typeof artifactDefinitions)[number]['kind'];
 

--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -11,6 +11,7 @@ export type DataStreamDelta = {
     | 'text-delta'
     | 'code-delta'
     | 'sheet-delta'
+    | 'profile-card-delta'
     | 'image-delta'
     | 'title'
     | 'id'

--- a/lib/ai/tools/get-profiles.ts
+++ b/lib/ai/tools/get-profiles.ts
@@ -1,0 +1,35 @@
+import { tool, DataStreamWriter } from 'ai';
+import { z } from 'zod';
+import { Session } from 'next-auth';
+
+interface GetProfilesProps {
+  session: Session;
+  dataStream: DataStreamWriter;
+}
+
+export const getProfiles = ({ dataStream }: GetProfilesProps) =>
+  tool({
+    description: 'Fetch profile information for people or companies',
+    parameters: z.object({
+      query: z.string().describe('search query'),
+      limit: z.number().min(1).max(3).default(1),
+    }),
+    execute: async ({ query, limit }) => {
+      // TODO: replace with real data fetching
+      const results = Array.from({ length: limit }).map((_, idx) => ({
+        name: `Result ${idx + 1}`,
+        title: 'Unknown',
+        company: query,
+        matchScore: 1,
+      }));
+
+      results.forEach((profile) => {
+        dataStream.writeData({
+          type: 'profile-card-delta',
+          content: JSON.stringify(profile),
+        });
+      });
+
+      return { results };
+    },
+  });

--- a/lib/artifacts/server.ts
+++ b/lib/artifacts/server.ts
@@ -3,6 +3,7 @@ import { imageDocumentHandler } from '@/artifacts/image/server';
 import { websetDocumentHandler } from '@/artifacts/webset/server';
 import { sheetDocumentHandler } from '@/artifacts/sheet/server';
 import { textDocumentHandler } from '@/artifacts/text/server';
+import { profileCardDocumentHandler } from '@/artifacts/profile-card/server';
 import { ArtifactKind } from '@/components/artifact';
 import { DataStreamWriter } from 'ai';
 import { Document } from '../db/schema';
@@ -96,6 +97,7 @@ export const documentHandlersByArtifactKind: Array<DocumentHandler> = [
   imageDocumentHandler,
   sheetDocumentHandler,
   websetDocumentHandler,
+  profileCardDocumentHandler,
 ];
 
-export const artifactKinds = ['text', 'code', 'image', 'sheet', 'webset'] as const;
+export const artifactKinds = ['text', 'code', 'image', 'sheet', 'webset', 'profile_card'] as const;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -109,7 +109,7 @@ export const document = pgTable(
     createdAt: timestamp('createdAt').notNull(),
     title: text('title').notNull(),
     content: text('content'),
-    kind: varchar('text', { enum: ['text', 'code', 'image', 'sheet', 'webset'] })
+    kind: varchar('text', { enum: ['text', 'code', 'image', 'sheet', 'webset', 'profile_card'] })
       .notNull()
       .default('text'),
     userId: uuid('userId')

--- a/tests/routes/profile-card.test.ts
+++ b/tests/routes/profile-card.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '../fixtures';
+import { artifactKinds, documentHandlersByArtifactKind } from '@/lib/artifacts/server';
+
+test.describe('profile_card artifact registration', () => {
+  test('artifactKinds includes profile_card', async () => {
+    expect(artifactKinds).toContain('profile_card');
+  });
+
+  test('document handlers include profile_card handler', async () => {
+    const hasHandler = documentHandlersByArtifactKind.some(h => h.kind === 'profile_card');
+    expect(hasHandler).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add ProfileCard component and artifact
- implement server/client handlers for profile cards
- expose `getProfiles` tool in chat route
- register new profile card artifact and DB kind
- add route test for profile card registration
- fix server handler return type

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*