### PR TITLE
Add Exa API integration for webset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ AUTH_SECRET=****
 
 # Get your xAI API Key here for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
+EXA_API_KEY=****
 
 # Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
 BLOB_READ_WRITE_TOKEN=****

--- a/app/(chat)/api/exa/route.ts
+++ b/app/(chat)/api/exa/route.ts
@@ -1,0 +1,31 @@
+import { auth } from '@/app/(auth)/auth';
+import { ChatSDKError } from '@/lib/errors';
+import { resultsToCSV, searchExa } from '@/lib/exa';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('query');
+  const category = searchParams.get('category') ?? 'company';
+  const numResults = Number(searchParams.get('numResults') || '10');
+
+  if (!query) {
+    return new ChatSDKError(
+      'bad_request:api',
+      'Parameter query is required.'
+    ).toResponse();
+  }
+
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:api').toResponse();
+  }
+
+  try {
+    const results = await searchExa({ query, category, numResults });
+    const csv = resultsToCSV(results);
+    return Response.json({ csv }, { status: 200 });
+  } catch (error: any) {
+    return new ChatSDKError('bad_request:api', error.message).toResponse();
+  }
+}

--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -1,78 +1,28 @@
-import { myProvider } from '@/lib/ai/providers';
-import { websetPrompt, updateDocumentPrompt } from '@/lib/ai/prompts';
 import { createDocumentHandler } from '@/lib/artifacts/server';
-import { streamObject } from 'ai';
-import { z } from 'zod';
+import { resultsToCSV, searchExa } from '@/lib/exa';
 
 export const websetDocumentHandler = createDocumentHandler<'webset'>({
   kind: 'webset',
   onCreateDocument: async ({ title, dataStream }) => {
-    let draftContent = '';
-
-    const { fullStream } = streamObject({
-      model: myProvider.languageModel('artifact-model'),
-      system: websetPrompt,
-      prompt: title,
-      schema: z.object({
-        csv: z.string().describe('CSV data'),
-      }),
-    });
-
-    for await (const delta of fullStream) {
-      const { type } = delta;
-
-      if (type === 'object') {
-        const { object } = delta;
-        const { csv } = object;
-
-        if (csv) {
-          dataStream.writeData({
-            type: 'sheet-delta',
-            content: csv,
-          });
-
-          draftContent = csv;
-        }
-      }
-    }
+    const results = await searchExa({ query: title, category: 'company' });
+    const csv = resultsToCSV(results);
 
     dataStream.writeData({
       type: 'sheet-delta',
-      content: draftContent,
+      content: csv,
     });
 
-    return draftContent;
+    return csv;
   },
   onUpdateDocument: async ({ document, description, dataStream }) => {
-    let draftContent = '';
+    const results = await searchExa({ query: description, category: 'company' });
+    const csv = resultsToCSV(results);
 
-    const { fullStream } = streamObject({
-      model: myProvider.languageModel('artifact-model'),
-      system: updateDocumentPrompt(document.content, 'webset'),
-      prompt: description,
-      schema: z.object({
-        csv: z.string(),
-      }),
+    dataStream.writeData({
+      type: 'sheet-delta',
+      content: csv,
     });
 
-    for await (const delta of fullStream) {
-      const { type } = delta;
-
-      if (type === 'object') {
-        const { object } = delta;
-        const { csv } = object;
-
-        if (csv) {
-          dataStream.writeData({
-            type: 'sheet-delta',
-            content: csv,
-          });
-
-          draftContent = csv;
-        }
-      }
-    }
-
-    return draftContent;
+    return csv;
   },
 });

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -5,7 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { ChevronDown, Code, Filter, Maximize2, Plus, SlidersHorizontal, Zap } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -14,13 +14,19 @@ interface WebsetTableProps {
 }
 
 export function WebsetTable({ csv }: WebsetTableProps) {
+  const [csvData, setCsvData] = useState(csv);
+
+  useEffect(() => {
+    setCsvData(csv);
+  }, [csv]);
+
   const { headers, rows } = useMemo(() => {
-    const parsed = parse<string[]>(csv || "", { skipEmptyLines: true });
+    const parsed = parse<string[]>(csvData || "", { skipEmptyLines: true });
     const data = parsed.data as string[][];
     const headers = data.length > 0 ? data[0] : [];
     const rows = data.length > 1 ? data.slice(1) : [];
     return { headers, rows };
-  }, [csv]);
+  }, [csvData]);
 
   const [filters, setFilters] = useState<Record<string, string>>({});
   const [sortedColumn, setSortedColumn] = useState<string | null>(null);
@@ -240,7 +246,27 @@ export function WebsetTable({ csv }: WebsetTableProps) {
         </Table>
       </div>
       <div className="flex justify-center p-4 border-t border-[#2d2640]">
-        <Button variant="outline" className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]">
+        <Button
+          variant="outline"
+          className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]"
+          onClick={async () => {
+            const query = prompt('Search query');
+            if (!query) return;
+            try {
+              const res = await fetch(`/api/exa?query=${encodeURIComponent(query)}`);
+              if (res.ok) {
+                const data = await res.json();
+                if (data.csv) {
+                  setCsvData((prev) => `${prev.trim()}\n${data.csv}`);
+                }
+              } else {
+                console.error('Failed to fetch results');
+              }
+            } catch (err) {
+              console.error(err);
+            }
+          }}
+        >
           <span className="text-[#a57eeb]">Find more results</span>
         </Button>
       </div>

--- a/lib/exa.ts
+++ b/lib/exa.ts
@@ -1,0 +1,49 @@
+export interface ExaResult {
+  title: string;
+  url: string;
+  author?: string;
+  published?: string;
+}
+
+export async function searchExa({
+  query,
+  category = 'company',
+  numResults = 10,
+}: {
+  query: string;
+  category?: string;
+  numResults?: number;
+}): Promise<ExaResult[]> {
+  const apiKey = process.env.EXA_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing EXA_API_KEY');
+  }
+
+  const response = await fetch('https://api.exa.ai/search', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify({ query, category, numResults }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Exa API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.results || [];
+}
+
+export function resultsToCSV(results: ExaResult[]): string {
+  const headers = ['Title', 'URL', 'Author', 'Published'];
+  const rows = results.map((r) => [
+    r.title?.replace(/"/g, '""') || '',
+    r.url || '',
+    r.author || '',
+    r.published || '',
+  ]);
+  const csvRows = rows.map((row) => row.map((c) => `"${c}"`).join(','));
+  return [headers.join(','), ...csvRows].join('\n');
+}


### PR DESCRIPTION
## Summary
- add `EXA_API_KEY` env var placeholder
- create Exa client helper and CSV utility
- add `/api/exa` route to proxy Exa search
- fetch Exa results when creating or updating webset documents
- allow webset table to search for more results from Exa

## Testing
- `pnpm test` *(fails: Command "playwright" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413f199e108326b42195f2058c49cf