### PR TITLE
Implement Webset query input and Exa helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,10 @@ POSTGRES_URL=****
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# OpenAI key for parsing webset criteria
+OPENAI_API_KEY=****
+
+# Exa API credentials
+EXA_API_KEY=****
+EXA_BASE=https://api.exa.ai

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,9 @@
+import { QueryForm } from '@/components/QueryForm';
+
+export default function Home() {
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center">
+      <QueryForm />
+    </main>
+  );
+}

--- a/components/CriteriaDialog.tsx
+++ b/components/CriteriaDialog.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
+import { Button } from './ui/button';
+
+export interface CriteriaDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  category: string;
+  criteria: Array<string>;
+  onConfirm: (category: string, criteria: Array<string>) => void;
+}
+
+/**
+ * Displays parsed criteria allowing the user to confirm or edit before search.
+ */
+export function CriteriaDialog({
+  open,
+  onOpenChange,
+  category,
+  criteria,
+  onConfirm,
+}: CriteriaDialogProps) {
+  const [localCategory, setLocalCategory] = useState(category);
+  const [localCriteria, setLocalCriteria] = useState(criteria);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Confirm criteria</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-2 py-2">
+          <input
+            className="border rounded-md px-2 py-1"
+            value={localCategory}
+            onChange={(e) => setLocalCategory(e.target.value)}
+          />
+          {localCriteria.map((c, i) => (
+            <input
+              key={c}
+              className="border rounded-md px-2 py-1"
+              value={c}
+              onChange={(e) => {
+                const arr = [...localCriteria];
+                arr[i] = e.target.value;
+                setLocalCriteria(arr);
+              }}
+            />
+          ))}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            type="button"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onConfirm(localCategory, localCriteria)}
+            type="button"
+          >
+            Confirm
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/QueryForm.tsx
+++ b/components/QueryForm.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+import { parseCriteria, type ParsedCriteria } from '@/lib/parseCriteria';
+import { CriteriaDialog } from './CriteriaDialog';
+
+/**
+ * Collects a natural language query and converts it to searchable criteria.
+ */
+export function QueryForm() {
+  const [query, setQuery] = useState('');
+  const [parsed, setParsed] = useState<ParsedCriteria | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!query) return;
+    const result = await parseCriteria(query);
+    setParsed(result);
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="flex gap-2 w-full max-w-xl mx-auto p-4"
+      >
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search companies, people..."
+        />
+        <Button type="submit">Search</Button>
+      </form>
+      {parsed && (
+        <CriteriaDialog
+          open={open}
+          onOpenChange={setOpen}
+          category={parsed.category}
+          criteria={parsed.criteria}
+          onConfirm={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/lib/exa.ts
+++ b/lib/exa.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+
+import axios from 'axios';
+
+/**
+ * Shared Axios instance for communicating with the Exa Websets API.
+ */
+const exaClient = axios.create({
+  baseURL: process.env.EXA_BASE ?? 'https://api.exa.ai',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-api-key': process.env.EXA_API_KEY ?? '',
+  },
+});
+
+export interface CreateWebsetBody {
+  category: string;
+  criteria: Array<string>;
+}
+
+/**
+ * Create a new Webset with the given category and criteria.
+ */
+export async function createWebset(body: CreateWebsetBody) {
+  const { data } = await exaClient.post<{ id: string }>('/v1/websets', body);
+  return data;
+}
+
+/**
+ * Fetch all items for the specified Webset ID.
+ */
+export async function getWebsetItems(id: string) {
+  const { data } = await exaClient.get(`/v1/websets/${id}/items`);
+  return data;
+}
+
+/**
+ * Enrich a Webset with additional attributes.
+ */
+export async function enrichWebset<T extends Record<string, unknown>>(
+  id: string,
+  body: T,
+) {
+  const { data } = await exaClient.post(`/v1/websets/${id}/enrich`, body);
+  return data;
+}
+
+/**
+ * Search within a Webset using the provided filters.
+ */
+export async function searchWebset<T extends Record<string, unknown>>(
+  id: string,
+  body: T,
+) {
+  const { data } = await exaClient.post(`/v1/websets/${id}/search`, body);
+  return data;
+}
+
+/**
+ * Export a Webset as CSV data.
+ */
+export async function exportWebset(id: string) {
+  const { data } = await exaClient.get(`/v1/websets/${id}/export`);
+  return data;
+}

--- a/lib/parseCriteria.ts
+++ b/lib/parseCriteria.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+
+/** Structure returned by `parseCriteria`. */
+export interface ParsedCriteria {
+  category: string;
+  criteria: Array<string>;
+}
+
+const tool = {
+  type: 'function',
+  function: {
+    name: 'returnCriteria',
+    parameters: {
+      type: 'object',
+      properties: {
+        category: { type: 'string' },
+        criteria: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['category', 'criteria'],
+    },
+  },
+};
+
+/**
+ * Calls OpenAI's chat API to parse a research query into structured criteria.
+ */
+export async function parseCriteria(query: string): Promise<ParsedCriteria> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Extract a category and list of search criteria from the user request. Respond using the returnCriteria function.',
+        },
+        { role: 'user', content: query },
+      ],
+      tools: [tool],
+      tool_choice: { type: 'function', function: { name: 'returnCriteria' } },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to parse criteria');
+  }
+
+  const json = await res.json();
+  const toolCall = json.choices?.[0]?.message?.tool_calls?.[0];
+  if (!toolCall) {
+    throw new Error('No tool call found');
+  }
+
+  return JSON.parse(toolCall.function.arguments);
+}


### PR DESCRIPTION
## Summary
- add OpenAI/Exa env vars
- wrap Exa Websets API
- OpenAI criteria parser
- generic Dialog component
- query input with criteria confirmation dialog
- basic landing page wiring up query form

## Testing
- `pnpm exec next lint`
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_6853e0ee1e288326acfa9da9c41c2a8d