### PR TITLE
Add ExampleCorp webset demo dataset

### DIFF
--- a/artifacts/webset/client.tsx
+++ b/artifacts/webset/client.tsx
@@ -33,6 +33,14 @@ export const websetArtifact = new Artifact<'webset', Metadata>({
     onSaveContent,
     status,
   }) => {
+    if (!content) {
+      return (
+        <div className="p-4 text-sm text-muted-foreground">
+          No data available.
+        </div>
+      );
+    }
+
     return <WebsetTable csv={content} />;
   },
   actions: [

--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -9,6 +9,14 @@ export const websetDocumentHandler = createDocumentHandler<'webset'>({
   onCreateDocument: async ({ title, dataStream }) => {
     let draftContent = '';
 
+    // Provide demo data for the ExampleCorp employees prompt without calling the model
+    if (title && title.toLowerCase().includes('examplecorp employees')) {
+      draftContent =
+        'Name,Title,Email\nAlice Johnson,CEO,alice@example.com\nBob Smith,CTO,bob@example.com\nCarol Davis,COO,carol@example.com';
+      dataStream.writeData({ type: 'sheet-delta', content: draftContent });
+      return draftContent;
+    }
+
     const { fullStream } = streamObject({
       model: myProvider.languageModel('artifact-model'),
       system: websetPrompt,

--- a/tests/routes/webset-demo.test.ts
+++ b/tests/routes/webset-demo.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '../fixtures';
+import { websetDocumentHandler } from '@/artifacts/webset/server';
+
+test('returns demo data for ExampleCorp employees', async () => {
+  const outputs: any[] = [];
+  const dataStream = { writeData: (data: any) => outputs.push(data) } as any;
+  await websetDocumentHandler.onCreateDocument({
+    id: '1',
+    title: 'Create a webset of ExampleCorp employees',
+    dataStream,
+    session: {} as any,
+  });
+  expect(outputs[0]).toEqual({
+    type: 'sheet-delta',
+    content:
+      'Name,Title,Email\nAlice Johnson,CEO,alice@example.com\nBob Smith,CTO,bob@example.com\nCarol Davis,COO,carol@example.com',
+  });
+});


### PR DESCRIPTION
## Summary
- add placeholder display when webset artifact has no data
- serve a predefined ExampleCorp employee CSV when the user asks to create that webset
- test the ExampleCorp employee demo data

## Testing
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e4d72188326b787ccce8f07e716