### PR TITLE
Refine webset artifact styling

### DIFF
--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -1,13 +1,37 @@
 "use client";
 import { parse } from "papaparse";
-import { Button } from "@/components/ui/button";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { ChevronDown, Code, Filter, Maximize2, Plus, SlidersHorizontal, Zap } from "lucide-react";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-
 import { useMemo, useState } from "react";
+
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  ChevronDown,
+  Code,
+  Filter,
+  Maximize2,
+  Plus,
+  SlidersHorizontal,
+  Zap,
+} from "lucide-react";
 
 interface WebsetTableProps {
   csv: string;
@@ -24,14 +48,14 @@ export function WebsetTable({ csv }: WebsetTableProps) {
 
   const [filters, setFilters] = useState<Record<string, string>>({});
   const [sortedColumn, setSortedColumn] = useState<string | null>(null);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
   const filteredRows = useMemo(() => {
     return rows.filter((row) =>
       headers.every((header, idx) => {
         const filter = filters[header];
         if (!filter) return true;
-        const cell = row[idx] || '';
+        const cell = row[idx] || "";
         const numeric = /^\d+(?:\.\d+)?$/.test(cell);
         if (numeric && /^\d+(?:\.\d+)?$/.test(filter)) {
           return Number(cell) >= Number(filter);
@@ -46,14 +70,14 @@ export function WebsetTable({ csv }: WebsetTableProps) {
     const idx = headers.indexOf(sortedColumn);
     if (idx === -1) return filteredRows;
     const sorted = [...filteredRows].sort((a, b) => {
-      const av = a[idx] || '';
-      const bv = b[idx] || '';
+      const av = a[idx] || "";
+      const bv = b[idx] || "";
       const aNum = parseFloat(av);
       const bNum = parseFloat(bv);
       if (!isNaN(aNum) && !isNaN(bNum)) {
-        return sortDirection === 'asc' ? aNum - bNum : bNum - aNum;
+        return sortDirection === "asc" ? aNum - bNum : bNum - aNum;
       }
-      return sortDirection === 'asc'
+      return sortDirection === "asc"
         ? av.localeCompare(bv)
         : bv.localeCompare(av);
     });
@@ -61,28 +85,24 @@ export function WebsetTable({ csv }: WebsetTableProps) {
   }, [filteredRows, headers, sortedColumn, sortDirection]);
 
   return (
-    <div className="w-full bg-[#1e1a2e] text-gray-200 min-h-screen">
-      <div className="flex items-center justify-between p-4 border-b border-[#2d2640]">
-        <div className="flex items-center gap-4">
+    <div className="w-full bg-white text-gray-900 border rounded-md">
+      <div className="flex items-center justify-between p-4 border-b gap-4">
+        <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
-              >
+              <Button variant="outline" size="sm" className="h-8 gap-1">
                 <Filter className="h-4 w-4" />
                 <span>Filter</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="bg-[#2d2640] border-[#3d3654] p-2 space-y-2">
+            <DropdownMenuContent className="p-2 space-y-2">
               {headers.map((header) => (
                 <div key={header} className="flex items-center gap-2">
                   <span className="w-32 text-xs">{header}</span>
                   <input
-                    className="flex-1 rounded bg-[#1e1a2e] border border-[#3d3654] px-2 py-1 text-xs"
+                    className="flex-1 rounded border px-2 py-1 text-xs"
                     placeholder="Filter"
-                    value={filters[header] || ''}
+                    value={filters[header] || ""}
                     onChange={(e) =>
                       setFilters({ ...filters, [header]: e.target.value })
                     }
@@ -93,40 +113,30 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           </DropdownMenu>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
-              >
+              <Button variant="outline" size="sm" className="h-8 gap-1">
                 <SlidersHorizontal className="h-4 w-4" />
                 <span>Sort</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="bg-[#2d2640] border-[#3d3654]">
+            <DropdownMenuContent>
               {headers.map((header) => (
                 <DropdownMenuItem
                   key={header}
                   onSelect={() => setSortedColumn(header)}
-                  className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
                 >
                   {header}
                 </DropdownMenuItem>
               ))}
               <DropdownMenuItem
                 onSelect={() =>
-                  setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+                  setSortDirection((d) => (d === "asc" ? "desc" : "asc"))
                 }
-                className="cursor-pointer hover:bg-[#3d3654] focus:bg-[#3d3654]"
               >
-                Direction: {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+                Direction: {sortDirection === "asc" ? "Ascending" : "Descending"}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
-          >
+          <Button variant="outline" size="sm" className="h-8 gap-1">
             <Code className="h-4 w-4" />
             <span>Get Code</span>
           </Button>
@@ -134,45 +144,37 @@ export function WebsetTable({ csv }: WebsetTableProps) {
         <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 gap-1 bg-[#2d2640] border-[#3d3654] text-gray-300 hover:bg-[#3d3654] hover:text-white"
-              >
+              <Button variant="outline" size="sm" className="h-8 gap-1">
                 <span>Actions</span>
                 <ChevronDown className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="bg-[#2d2640] border-[#3d3654] text-gray-200">
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Export</DropdownMenuItem>
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Share</DropdownMenuItem>
-              <DropdownMenuItem className="hover:bg-[#3d3654] focus:bg-[#3d3654]">Delete</DropdownMenuItem>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem>Export</DropdownMenuItem>
+              <DropdownMenuItem>Share</DropdownMenuItem>
+              <DropdownMenuItem>Delete</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button size="sm" className="h-8 gap-1 bg-[#8a57db] hover:bg-[#9a67eb] text-white">
+          <Button size="sm" className="h-8 gap-1">
             <Zap className="h-4 w-4" />
             <span>Add Enrichment</span>
           </Button>
         </div>
       </div>
       <div className="overflow-auto">
-        <Table className="border-collapse">
+        <Table>
           <TableHeader>
-            <TableRow className="border-b border-[#2d2640]">
-              <TableHead className="w-12 text-center text-gray-400 font-normal">#</TableHead>
-              {headers.map((header, idx) => (
-                <TableHead key={idx} className="min-w-[150px] text-gray-400 font-normal">
+            <TableRow>
+              <TableHead className="w-12 text-center font-normal">#</TableHead>
+              {headers.map((header) => (
+                <TableHead key={header} className="min-w-[150px] font-normal">
                   <div className="flex items-center gap-2">
                     <span className="text-xs">{header}</span>
                   </div>
                 </TableHead>
               ))}
               <TableHead className="w-10">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
-                >
+                <Button variant="ghost" size="icon" className="h-8 w-8">
                   <Plus className="h-4 w-4" />
                 </Button>
               </TableHead>
@@ -180,19 +182,25 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           </TableHeader>
           <TableBody>
             {sortedRows.map((row, rowIdx) => (
-              <TableRow key={rowIdx} className="border-b border-[#2d2640] hover:bg-[#2d2640]">
-                <TableCell className="text-center text-sm text-gray-400">{rowIdx + 1}</TableCell>
+              <TableRow key={row.join("|") || rowIdx}>
+                <TableCell className="text-center text-sm text-muted-foreground">
+                  {rowIdx + 1}
+                </TableCell>
                 {row.map((cell, cellIdx) => {
-                  const header = headers[cellIdx] || '';
-                  const isValidator = header.toLowerCase().includes('direct competitor');
-                  const isUrl = header.toLowerCase().includes('url');
-                  const content = cell || '';
+                  const header = headers[cellIdx] || "";
+                  const isValidator = header
+                    .toLowerCase()
+                    .includes("direct competitor");
+                  const isUrl = header.toLowerCase().includes("url");
+                  const content = cell || "";
                   return (
-                    <TableCell key={cellIdx} className="text-gray-300">
+                    <TableCell key={`${headers[cellIdx] ?? cellIdx}-${content}`} className="text-sm">
                       {isValidator ? (
-                        content.toLowerCase() === 'true' || content.toLowerCase() === 'match' || content === '1' ? (
+                        content.toLowerCase() === "true" ||
+                        content.toLowerCase() === "match" ||
+                        content === "1" ? (
                           <Badge
-                            className="h-6 px-3 rounded-[4px] bg-[#2ECC71] text-white text-[12px] font-semibold flex items-center justify-center"
+                            className="h-6 px-3 rounded bg-green-500 text-white text-xs font-semibold"
                             aria-label="Validation status: match"
                           >
                             MATCH
@@ -201,7 +209,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                           content && (
                             <Badge
                               variant="secondary"
-                              className="h-6 px-3 rounded-[4px] text-[12px] font-semibold flex items-center justify-center"
+                              className="h-6 px-3 rounded text-xs font-semibold"
                               aria-label="Validation status: mismatch"
                             >
                               Mismatch
@@ -209,13 +217,20 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                           )
                         )
                       ) : isUrl ? (
-                        <a href={content} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">
+                        <a
+                          href={content}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 underline"
+                        >
                           {content}
                         </a>
                       ) : (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span className="line-clamp-1 block max-w-[200px]">{content}</span>
+                            <span className="line-clamp-1 block max-w-[200px]">
+                              {content}
+                            </span>
                           </TooltipTrigger>
                           <TooltipContent>{content}</TooltipContent>
                         </Tooltip>
@@ -225,11 +240,7 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                 })}
                 <TableCell>
                   {rowIdx === 0 && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-gray-400 hover:text-white hover:bg-[#3d3654]"
-                    >
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
                       <Maximize2 className="h-4 w-4" />
                     </Button>
                   )}
@@ -239,9 +250,9 @@ export function WebsetTable({ csv }: WebsetTableProps) {
           </TableBody>
         </Table>
       </div>
-      <div className="flex justify-center p-4 border-t border-[#2d2640]">
-        <Button variant="outline" className="rounded-full px-6 bg-[#2d2640] border-[#3d3654] hover:bg-[#3d3654]">
-          <span className="text-[#a57eeb]">Find more results</span>
+      <div className="flex justify-center p-4 border-t">
+        <Button variant="outline" className="rounded-full px-6">
+          Find more results
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle webset artifact with shadcn table and buttons
- add white background, border, and tighter spacing for cleaner appearance

## Testing
- `pnpm lint` *(fails: Provide a text alternative through the alt attribute in components/ui/avatar.tsx)*
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a5a3e2c8324b2fce6843ced7a3d