### PR TITLE
feat: switch Exa snippet to Crustdata

### DIFF
--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -181,27 +181,35 @@ export function WebsetTable({ csv }: WebsetTableProps) {
                 <AlertDialogTitle>Integration Code</AlertDialogTitle>
               </AlertDialogHeader>
               <pre className="mt-4 bg-muted p-4 rounded-md text-sm overflow-x-auto">
-{`from exa_py import Exa
-from exa_py.websets.types import CreateWebsetParameters, CreateEnrichmentParameters
-import os
+  {`import os
+import requests
 
-exa = Exa(os.getenv('EXA_API_KEY'))
+api_key = os.getenv('CRUSTDATA_API_KEY')
+headers = {
+    "x-api-key": api_key,
+    "content-type": "application/json",
+}
 
-webset = exa.websets.create(
-    params=CreateWebsetParameters(
-        search={
-            "query": "software engineer in SF",
-            "criteria": [
-                "Currently employ or self-identifies as a software engineer",
-                "located in san francisco, ca"
-            ],
-        },
-        "count": 25
-    ),
-    enrichments=[
+payload = {
+    "search": {
+        "query": "software engineer in SF",
+        "criteria": [
+            "Currently employed or self-identifies as a software engineer",
+            "located in san francisco, ca",
+        ],
+        "count": 25,
+    },
+    "enrichments": [
         # ...
     ],
-)`}
+}
+
+response = requests.post(
+    "https://api.crustdata.com/websets",
+    json=payload,
+    headers=headers,
+)
+webset = response.json()`}
               </pre>
               <AlertDialogFooter>
                 <AlertDialogCancel>Close</AlertDialogCancel>


### PR DESCRIPTION
## Summary
- replace Exa webset sample with Crustdata integration snippet in Get Code dialog

## Testing
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68aac00191a483249a1fda0357df227e