### PR TITLE
feat(webset): add export share delete actions

### DIFF
--- a/artifacts/webset/client.tsx
+++ b/artifacts/webset/client.tsx
@@ -33,7 +33,14 @@ export const websetArtifact = new Artifact<'webset', Metadata>({
     onSaveContent,
     status,
   }) => {
-    return <WebsetTable csv={content} />;
+    return (
+      <WebsetTable
+        csv={content}
+        onDelete={() => {
+          onSaveContent('', false);
+        }}
+      />
+    );
   },
   actions: [
     {

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -282,7 +282,7 @@ const DocumentContent = ({ document }: { document: Document }) => {
           isInline={true}
         />
       ) : document.kind === 'webset' ? (
-        <WebsetTable csv={document.content ?? ''} />
+        <WebsetTable csv={document.content ?? ''} onDelete={() => {}} />
       ) : null}
     </div>
   );

--- a/components/webset-table.tsx
+++ b/components/webset-table.tsx
@@ -45,9 +45,10 @@ import {
 
 interface WebsetTableProps {
   csv: string;
+  onDelete: () => void;
 }
 
-export function WebsetTable({ csv }: WebsetTableProps) {
+export function WebsetTable({ csv, onDelete }: WebsetTableProps) {
   const { headers, rows } = useMemo(() => {
     const parsed = parse<string[]>(csv || "", { skipEmptyLines: true });
     const data = parsed.data as string[][];
@@ -61,6 +62,55 @@ export function WebsetTable({ csv }: WebsetTableProps) {
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [columnWidths, setColumnWidths] =
     useState<Record<string, number>>({});
+
+  const handleExport = async () => {
+    if (!window.confirm("Export table as CSV?")) return;
+    const blob = new Blob([csv], { type: "text/csv" });
+    try {
+      if ("showSaveFilePicker" in window) {
+        // @ts-ignore: File System Access API
+        const handle = await window.showSaveFilePicker({
+          suggestedName: "webset.csv",
+          types: [
+            { description: "CSV Files", accept: { "text/csv": [".csv"] } },
+          ],
+        });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } else {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "webset.csv";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
+    } catch (error) {
+      console.error("Export failed", error);
+    }
+  };
+
+  const handleShare = async () => {
+    const shareUrl = window.location.href;
+    try {
+      if (navigator.share) {
+        await navigator.share({ url: shareUrl });
+      } else {
+        window.prompt("Share this link", shareUrl);
+      }
+    } catch {
+      window.prompt("Share this link", shareUrl);
+    }
+  };
+
+  const handleDelete = () => {
+    if (window.confirm("Delete this webset data?")) {
+      onDelete();
+    }
+  };
 
   const startResizing = (header: string) => (e: ReactMouseEvent) => {
     e.preventDefault();
@@ -226,9 +276,9 @@ webset = response.json()`}
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem>Export</DropdownMenuItem>
-              <DropdownMenuItem>Share</DropdownMenuItem>
-              <DropdownMenuItem>Delete</DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleExport}>Export</DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleShare}>Share</DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
           <Button size="sm" className="h-8 gap-1">


### PR DESCRIPTION
## Summary
- enable export, share, and delete options in webset Actions menu
- allow webset table export to CSV with save dialog
- hook delete action to clear artifact data

## Testing
- `pnpm test` *(fails: This module cannot be imported from a Client Component module. It should only be used from a Server Component)*

------
https://chatgpt.com/codex/tasks/task_e_68aad08f8b448324bc62b0f15888c2be