### PR TITLE
feat(webset): integrate crustdata APIs

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -20,6 +20,11 @@ export async function saveOpenAIApiKeyAsCookie(apiKey: string) {
   cookieStore.set('openai-api-key', apiKey);
 }
 
+export async function saveCrustdataApiKeyAsCookie(apiKey: string) {
+  const cookieStore = await cookies();
+  cookieStore.set('crustdata-api-key', apiKey);
+}
+
 export async function generateTitleFromUserMessage({
   message,
   apiKey,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -23,6 +23,7 @@ import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
+import { getCrustdata } from '@/lib/ai/tools/get-crustdata';
 import { isProductionEnvironment } from '@/lib/constants';
 import { getProvider } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
@@ -167,6 +168,7 @@ export async function POST(request: Request) {
                   'createDocument',
                   'updateDocument',
                   'requestSuggestions',
+                  'getCrustdata',
                 ],
           experimental_transform: smoothStream({ chunking: 'word' }),
           experimental_generateMessageId: generateUUID,
@@ -179,6 +181,7 @@ export async function POST(request: Request) {
               dataStream,
               apiKey,
             }),
+            getCrustdata,
           },
           onFinish: async ({ response }) => {
             if (session.user?.id) {

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -54,6 +54,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   const cookieStore = await cookies();
   const chatModelFromCookie = cookieStore.get('chat-model');
   const apiKeyFromCookie = cookieStore.get('openai-api-key');
+  const crustdataApiKeyFromCookie = cookieStore.get('crustdata-api-key');
 
   if (!chatModelFromCookie) {
     return (
@@ -67,6 +68,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
           session={session}
           autoResume={true}
           initialApiKey={apiKeyFromCookie?.value ?? ''}
+          initialCrustdataApiKey={crustdataApiKeyFromCookie?.value ?? ''}
         />
         <DataStreamHandler id={id} />
       </>
@@ -84,6 +86,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         session={session}
         autoResume={true}
         initialApiKey={apiKeyFromCookie?.value ?? ''}
+        initialCrustdataApiKey={crustdataApiKeyFromCookie?.value ?? ''}
       />
       <DataStreamHandler id={id} />
     </>

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -19,6 +19,7 @@ export default async function Page() {
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get('chat-model');
   const apiKeyFromCookie = cookieStore.get('openai-api-key');
+  const crustdataApiKeyFromCookie = cookieStore.get('crustdata-api-key');
 
   if (!modelIdFromCookie) {
     return (
@@ -33,6 +34,7 @@ export default async function Page() {
           session={session}
            autoResume={false}
           initialApiKey={apiKeyFromCookie?.value ?? ''}
+          initialCrustdataApiKey={crustdataApiKeyFromCookie?.value ?? ''}
         />
         <DataStreamHandler id={id} />
       </>
@@ -51,6 +53,7 @@ export default async function Page() {
         session={session}
         autoResume={false}
         initialApiKey={apiKeyFromCookie?.value ?? ''}
+        initialCrustdataApiKey={crustdataApiKeyFromCookie?.value ?? ''}
       />
       <DataStreamHandler id={id} />
     </>

--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -1,48 +1,97 @@
 import { getProvider } from '@/lib/ai/providers';
-import { websetPrompt, updateDocumentPrompt } from '@/lib/ai/prompts';
+import { updateDocumentPrompt } from '@/lib/ai/prompts';
 import { createDocumentHandler } from '@/lib/artifacts/server';
+import {
+  fetchCompanyProfile,
+  fetchCompanyPeople,
+  getCrustdataApiKey,
+  companyToCsv,
+  peopleToCsv,
+} from '@/lib/crustdata';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
+function parseCompanyQuery(input: string):
+  | { company_id: number }
+  | { company_domain: string }
+  | null {
+  const trimmed = input.trim();
+  const asNumber = Number(trimmed);
+  if (!Number.isNaN(asNumber)) {
+    return { company_id: asNumber };
+  }
+  const match = trimmed.match(/([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/);
+  if (match) {
+    return { company_domain: match[1] };
+  }
+  return null;
+}
+
+
 export const websetDocumentHandler = createDocumentHandler<'webset'>({
   kind: 'webset',
-  onCreateDocument: async ({ title, dataStream, apiKey }) => {
-    let draftContent = '';
-
-    const provider = getProvider(apiKey);
-    const { fullStream } = streamObject({
-      model: provider.languageModel('artifact-model'),
-      system: websetPrompt,
-      prompt: title,
-      schema: z.object({
-        csv: z.string().describe('CSV data'),
-      }),
-    });
-
-    for await (const delta of fullStream) {
-      const { type } = delta;
-
-      if (type === 'object') {
-        const { object } = delta;
-        const { csv } = object;
-
-        if (csv) {
-          dataStream.writeData({
-            type: 'sheet-delta',
-            content: csv,
-          });
-
-          draftContent = csv;
-        }
-      }
+  onCreateDocument: async ({ title, dataStream }) => {
+    const token = await getCrustdataApiKey();
+    if (!token) {
+      dataStream.writeData({
+        type: 'error',
+        content: 'Missing Crustdata API key',
+      });
+      return '';
     }
 
-    dataStream.writeData({
-      type: 'sheet-delta',
-      content: draftContent,
-    });
+    const query = parseCompanyQuery(title);
+    if (!query) {
+      dataStream.writeData({
+        type: 'error',
+        content: 'Please provide a company domain or ID.',
+      });
+      return '';
+    }
 
-    return draftContent;
+    try {
+      const profile = await fetchCompanyProfile(token, query);
+      if (!profile.length) {
+        dataStream.writeData({
+          type: 'error',
+          content: 'No company data found.',
+        });
+        return '';
+      }
+
+      let csv = companyToCsv(profile);
+      dataStream.writeData({ type: 'sheet-delta', content: csv });
+
+      // attempt to fetch people dump link
+      try {
+        const company = profile[0];
+        if (company?.company_id) {
+          const people = await fetchCompanyPeople(token, {
+            company_id: company.company_id,
+            s3_username: 'ext-user-crustdata',
+          });
+          const peopleRow = peopleToCsv(people);
+          csv += `\n${peopleRow}`;
+          dataStream.writeData({
+            type: 'sheet-delta',
+            content: `\n${peopleRow}`,
+          });
+        }
+      } catch (err) {
+        dataStream.writeData({
+          type: 'error',
+          content: 'Failed to fetch company people.',
+        });
+      }
+
+      return csv;
+    } catch (err: unknown) {
+      dataStream.writeData({
+        type: 'error',
+        content: err instanceof Error ? err.message : 'Unknown error',
+      });
+      return '';
+    }
   },
   onUpdateDocument: async ({ document, description, dataStream, apiKey }) => {
     let draftContent = '';

--- a/components/chat-settings.tsx
+++ b/components/chat-settings.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { ModelSelector } from '@/components/model-selector';
 import { ApiKeyInput } from '@/components/api-key-input';
+import { CrustdataApiKeyInput } from '@/components/crustdata-api-key-input';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -17,12 +18,16 @@ export function ChatSettings({
   selectedModelId,
   apiKey,
   setApiKey,
+  crustdataApiKey,
+  setCrustdataApiKey,
   className,
 }: {
   session: Session;
   selectedModelId: string;
   apiKey: string;
   setApiKey: (key: string) => void;
+  crustdataApiKey: string;
+  setCrustdataApiKey: (key: string) => void;
   className?: string;
 }) {
   const [temperature, setTemperature] = useState('1');
@@ -42,6 +47,10 @@ export function ChatSettings({
       </PopoverTrigger>
       <PopoverContent className="w-64 p-4 flex flex-col gap-4">
         <ApiKeyInput apiKey={apiKey} setApiKey={setApiKey} />
+        <CrustdataApiKeyInput
+          apiKey={crustdataApiKey}
+          setApiKey={setCrustdataApiKey}
+        />
         <ModelSelector
           session={session}
           selectedModelId={selectedModelId}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -30,6 +30,7 @@ export function Chat({
   session,
   autoResume,
   initialApiKey = '',
+  initialCrustdataApiKey = '',
 }: {
   id: string;
   initialMessages: Array<UIMessage>;
@@ -39,6 +40,7 @@ export function Chat({
   session: Session;
   autoResume: boolean;
   initialApiKey?: string;
+  initialCrustdataApiKey?: string;
 }) {
   const { mutate } = useSWRConfig();
 
@@ -111,6 +113,9 @@ export function Chat({
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
   const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
   const [apiKey, setApiKey] = useState(initialApiKey);
+  const [crustdataApiKey, setCrustdataApiKey] = useState(
+    initialCrustdataApiKey,
+  );
 
   useAutoResume({
     autoResume,
@@ -159,6 +164,8 @@ export function Chat({
               selectedModelId={initialChatModel}
               apiKey={apiKey}
               setApiKey={setApiKey}
+              crustdataApiKey={crustdataApiKey}
+              setCrustdataApiKey={setCrustdataApiKey}
             />
           )}
         </form>

--- a/components/crustdata-api-key-input.tsx
+++ b/components/crustdata-api-key-input.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { startTransition, useState } from 'react';
+import { saveCrustdataApiKeyAsCookie } from '@/app/(chat)/actions';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+export function CrustdataApiKeyInput({
+  apiKey,
+  setApiKey,
+  className,
+}: {
+  apiKey: string;
+  setApiKey: (key: string) => void;
+  className?: string;
+}) {
+  const [mode, setMode] = useState(apiKey ? 'custom' : 'auto');
+  const [value, setValue] = useState(apiKey);
+
+  const handleModeChange = (val: string) => {
+    setMode(val);
+    if (val === 'auto') {
+      setValue('');
+      setApiKey('');
+      startTransition(() => {
+        saveCrustdataApiKeyAsCookie('');
+      });
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <Select value={mode} onValueChange={handleModeChange}>
+        <SelectTrigger className="w-full md:w-48">
+          <SelectValue placeholder="Crustdata API Key" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="auto">Auto</SelectItem>
+          <SelectItem value="custom">Custom</SelectItem>
+        </SelectContent>
+      </Select>
+      {mode === 'custom' && (
+        <div className="flex w-full items-center gap-2">
+          <Input
+            type="password"
+            placeholder="Crustdata API Key"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            variant="outline"
+            onClick={() => {
+              setApiKey(value);
+              startTransition(() => {
+                saveCrustdataApiKeyAsCookie(value);
+              });
+            }}
+          >
+            Save
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -48,6 +48,8 @@ function PureMultimodalInput({
   selectedModelId,
   apiKey,
   setApiKey,
+  crustdataApiKey,
+  setCrustdataApiKey,
 }: {
   chatId: string;
   input: UseChatHelpers['input'];
@@ -66,6 +68,8 @@ function PureMultimodalInput({
   selectedModelId: string;
   apiKey: string;
   setApiKey: (key: string) => void;
+  crustdataApiKey: string;
+  setCrustdataApiKey: (key: string) => void;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
@@ -308,6 +312,8 @@ function PureMultimodalInput({
           selectedModelId={selectedModelId}
           apiKey={apiKey}
           setApiKey={setApiKey}
+          crustdataApiKey={crustdataApiKey}
+          setCrustdataApiKey={setCrustdataApiKey}
         />
       </div>
 
@@ -336,6 +342,7 @@ export const MultimodalInput = memo(
       return false;
     if (prevProps.selectedModelId !== nextProps.selectedModelId) return false;
     if (prevProps.apiKey !== nextProps.apiKey) return false;
+    if (prevProps.crustdataApiKey !== nextProps.crustdataApiKey) return false;
 
     return true;
   },

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -98,6 +98,7 @@ You are a spreadsheet creation assistant. Create a spreadsheet in csv format bas
 
 export const websetPrompt = `
 You generate company and people information in csv format. Use the prompt to decide which fields to include.
+Always use the getCrustdata tool to fetch company profiles and people dump links; do not fabricate data.
 `;
 
 export const updateDocumentPrompt = (

--- a/lib/ai/tools/get-crustdata.ts
+++ b/lib/ai/tools/get-crustdata.ts
@@ -1,0 +1,64 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import {
+  fetchCompanyProfile,
+  fetchCompanyPeople,
+  getCrustdataApiKey,
+  type CompanyProfileResponse,
+  type CompanyPeopleResponse,
+} from '@/lib/crustdata';
+
+export const getCrustdata = tool({
+  description:
+    'Retrieve company profile information and optionally a people dump link from Crustdata',
+  parameters: z.object({
+    company: z
+      .string()
+      .describe('Company domain or numeric company_id to lookup'),
+    fields: z.array(z.string()).optional(),
+    includePeople: z
+      .boolean()
+      .optional()
+      .describe('Whether to fetch a people dump link'),
+    s3Username: z
+      .string()
+      .optional()
+      .describe('Required when includePeople is true'),
+  }),
+  execute: async ({ company, fields, includePeople, s3Username }) => {
+    const token = await getCrustdataApiKey();
+    if (!token) {
+      throw new Error('Missing Crustdata API key');
+    }
+
+    const isId = /^\d+$/.test(company);
+    const profile = await fetchCompanyProfile(token, {
+      ...(isId ? { company_id: Number(company) } : { company_domain: company }),
+      fields,
+    });
+
+    if (!includePeople) {
+      return { profile } as { profile: CompanyProfileResponse };
+    }
+
+    if (!s3Username) {
+      throw new Error('s3Username is required when includePeople is true');
+    }
+
+    const companyId = profile[0]?.company_id;
+    if (!companyId) {
+      throw new Error('Company ID not found for people lookup');
+    }
+
+    const people = await fetchCompanyPeople(token, {
+      company_id: companyId,
+      s3_username: s3Username,
+    });
+
+    return { profile, people } as {
+      profile: CompanyProfileResponse;
+      people: CompanyPeopleResponse;
+    };
+  },
+});
+

--- a/lib/crustdata/client.ts
+++ b/lib/crustdata/client.ts
@@ -1,0 +1,87 @@
+export const CRUSTDATA_API_BASE_URL = 'https://api.crustdata.com';
+const COMPANY_ENDPOINT = '/screener/company';
+const PEOPLE_ENDPOINT = '/screener/company/people';
+
+function buildQuery(params: Record<string, string | number | boolean | string[] | undefined>) {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      searchParams.set(key, value.join(','));
+    } else {
+      searchParams.set(key, String(value));
+    }
+  }
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+export const crustdataHeaders = (token: string): HeadersInit => ({
+  Authorization: `Token ${token}`,
+});
+
+export interface CompanyProfile {
+  company_id: number;
+  company_name: string;
+  company_website_domain?: string;
+  company_website?: string;
+  linkedin_profile_url?: string;
+  linkedin_id?: string;
+  hq_country?: string;
+  headquarters?: string;
+  employee_count_range?: string;
+  [key: string]: unknown;
+}
+
+export type CompanyProfileResponse = CompanyProfile[];
+
+export interface CompanyPeopleResponse {
+  s3_uri: string;
+}
+
+export interface CompanyProfileParams {
+  company_domain?: string | string[];
+  company_name?: string | string[];
+  company_linkedin_url?: string | string[];
+  company_id?: number | number[];
+  fields?: string | string[];
+  enrich_realtime?: boolean;
+  exact_match?: boolean;
+}
+
+export interface CompanyPeopleParams {
+  company_linkedin_id?: string | number;
+  company_id?: string | number;
+  company_name?: string;
+  s3_username: string;
+  version?: string;
+  job_id?: string;
+}
+
+export async function fetchCompanyProfile(
+  token: string,
+  params: CompanyProfileParams
+): Promise<CompanyProfileResponse> {
+  const res = await fetch(
+    `${CRUSTDATA_API_BASE_URL}${COMPANY_ENDPOINT}${buildQuery(params)}`,
+    { headers: crustdataHeaders(token) }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch company profile: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchCompanyPeople(
+  token: string,
+  params: CompanyPeopleParams
+): Promise<CompanyPeopleResponse> {
+  const res = await fetch(
+    `${CRUSTDATA_API_BASE_URL}${PEOPLE_ENDPOINT}${buildQuery(params)}`,
+    { headers: crustdataHeaders(token) }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch company people: ${res.status}`);
+  }
+  return res.json();
+}

--- a/lib/crustdata/index.ts
+++ b/lib/crustdata/index.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers';
+
+export * from './client';
+export * from './transform';
+
+export async function getCrustdataApiKey() {
+  const cookieStore = await cookies();
+  return cookieStore.get('crustdata-api-key')?.value;
+}

--- a/lib/crustdata/transform.ts
+++ b/lib/crustdata/transform.ts
@@ -1,0 +1,60 @@
+import type { CompanyPeopleResponse, CompanyProfile } from './client';
+
+export interface FlattenCompany {
+  company_name?: string;
+  company_id?: number;
+  linkedin_headcount?: number;
+  decision_maker_names?: string;
+  [key: string]: unknown;
+}
+
+export function flattenCompany(profile: CompanyProfile): FlattenCompany {
+  const flattened: FlattenCompany = {
+    company_name: profile.company_name,
+    company_id: profile.company_id,
+  };
+
+  const headcount: any = (profile as any).headcount;
+  if (headcount && typeof headcount === 'object') {
+    flattened.linkedin_headcount = headcount.linkedin_headcount;
+  }
+
+  const decisionMakers: any = (profile as any).decision_makers;
+  if (Array.isArray(decisionMakers)) {
+    flattened.decision_maker_names = decisionMakers
+      .map((dm: any) => dm?.name)
+      .filter(Boolean)
+      .join(';');
+  }
+
+  return flattened;
+}
+
+export function flattenPeople(res: CompanyPeopleResponse): Record<string, string> {
+  return { people_s3_uri: res.s3_uri };
+}
+
+export function toCsv(objects: Array<Record<string, unknown>>): string {
+  if (!objects.length) return '';
+  const headers = Object.keys(objects[0]);
+  const rows = objects.map((obj) =>
+    headers
+      .map((h) => {
+        const val = obj[h];
+        if (val === undefined || val === null) return '';
+        return String(val).replace(/"/g, '""');
+      })
+      .join(',')
+  );
+  return [headers.join(','), ...rows].join('\n');
+}
+
+export function companyToCsv(profiles: CompanyProfile[]): string {
+  const rows = profiles.map(flattenCompany);
+  return toCsv(rows);
+}
+
+export function peopleToCsv(res: CompanyPeopleResponse): string {
+  return toCsv([flattenPeople(res)]);
+}
+

--- a/tests/lib/crustdata/transform.spec.ts
+++ b/tests/lib/crustdata/transform.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { companyToCsv, peopleToCsv } from '@/lib/crustdata/transform';
+import type { CompanyPeopleResponse, CompanyProfile } from '@/lib/crustdata';
+
+test('companyToCsv flattens company name, headcount and decision makers', () => {
+  const profile: CompanyProfile = {
+    company_id: 1,
+    company_name: 'Acme Inc',
+    headcount: { linkedin_headcount: 123 },
+    decision_makers: [{ name: 'Alice' }, { name: 'Bob' }],
+  } as any;
+
+  const csv = companyToCsv([profile]);
+  expect(csv).toBe(
+    'company_name,company_id,linkedin_headcount,decision_maker_names\nAcme Inc,1,123,Alice;Bob'
+  );
+});
+
+test('peopleToCsv outputs s3 link row', () => {
+  const res: CompanyPeopleResponse = { s3_uri: 's3://bucket/file.jsonl.gz' };
+  const csv = peopleToCsv(res);
+  expect(csv).toBe('people_s3_uri\ns3://bucket/file.jsonl.gz');
+});
+


### PR DESCRIPTION
## Summary
- parse company identifier from prompt and fetch Crustdata profiles
- stream company data to sheets and append people dump link
- surface errors when API key missing or data unavailable
- add CSV transform utilities for company profiles and people dumps
- expose getCrustdata tool for profile and people lookups

## Testing
- `pnpm lint`
- `pnpm test` *(fails: This module cannot be imported from a Client Component module. It should only be used from a Server Component.)*

------
https://chatgpt.com/codex/tasks/task_e_68aac357f6c08324a1c762b56b66c6b9