### PR TITLE
Use Crustdata API for webset data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ Your app template should now be running on [localhost:3000](http://localhost:300
 ## Webset artifact
 
 The `webset` artifact shows company and people data in a table-style interface with buttons for filtering and sorting results. Tools like `createDocument` can generate a document with `kind: "webset"` to render this panel next to the chat.
+
+The table content is retrieved from the Crustdata Websets API. Provide your API token via the
+`CRUSTDATA_TOKEN` environment variable (a demo token is used if unset).

--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -1,80 +1,39 @@
-import { getProvider } from '@/lib/ai/providers';
-import { websetPrompt, updateDocumentPrompt } from '@/lib/ai/prompts';
 import { createDocumentHandler } from '@/lib/artifacts/server';
-import { streamObject } from 'ai';
-import { z } from 'zod';
+
+const CRUSTDATA_TOKEN =
+  process.env.CRUSTDATA_TOKEN || 'a8695e91fcf954209117407c1e29c04ae8715141';
+
+async function fetchWebsetCsv(query: string): Promise<string> {
+  const response = await fetch('https://api.crustdata.com/websets', {
+    method: 'POST',
+    headers: {
+      Authorization: `Token ${CRUSTDATA_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      search: { query },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Crustdata request failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { csv?: string };
+  return data.csv || '';
+}
 
 export const websetDocumentHandler = createDocumentHandler<'webset'>({
   kind: 'webset',
-  onCreateDocument: async ({ title, dataStream, apiKey }) => {
-    let draftContent = '';
-
-    const provider = getProvider(apiKey);
-    const { fullStream } = streamObject({
-      model: provider.languageModel('artifact-model'),
-      system: websetPrompt,
-      prompt: title,
-      schema: z.object({
-        csv: z.string().describe('CSV data'),
-      }),
-    });
-
-    for await (const delta of fullStream) {
-      const { type } = delta;
-
-      if (type === 'object') {
-        const { object } = delta;
-        const { csv } = object;
-
-        if (csv) {
-          dataStream.writeData({
-            type: 'sheet-delta',
-            content: csv,
-          });
-
-          draftContent = csv;
-        }
-      }
-    }
-
-    dataStream.writeData({
-      type: 'sheet-delta',
-      content: draftContent,
-    });
-
-    return draftContent;
+  onCreateDocument: async ({ title, dataStream }) => {
+    const csv = await fetchWebsetCsv(title);
+    dataStream.writeData({ type: 'sheet-delta', content: csv });
+    return csv;
   },
-  onUpdateDocument: async ({ document, description, dataStream, apiKey }) => {
-    let draftContent = '';
-
-    const provider = getProvider(apiKey);
-    const { fullStream } = streamObject({
-      model: provider.languageModel('artifact-model'),
-      system: updateDocumentPrompt(document.content, 'webset'),
-      prompt: description,
-      schema: z.object({
-        csv: z.string(),
-      }),
-    });
-
-    for await (const delta of fullStream) {
-      const { type } = delta;
-
-      if (type === 'object') {
-        const { object } = delta;
-        const { csv } = object;
-
-        if (csv) {
-          dataStream.writeData({
-            type: 'sheet-delta',
-            content: csv,
-          });
-
-          draftContent = csv;
-        }
-      }
-    }
-
-    return draftContent;
+  onUpdateDocument: async ({ description, dataStream }) => {
+    const csv = await fetchWebsetCsv(description);
+    dataStream.writeData({ type: 'sheet-delta', content: csv });
+    return csv;
   },
 });
+

--- a/lib/artifacts/server.ts
+++ b/lib/artifacts/server.ts
@@ -6,7 +6,6 @@ import { textDocumentHandler } from '@/artifacts/text/server';
 import { ArtifactKind } from '@/components/artifact';
 import { DataStreamWriter } from 'ai';
 import { Document } from '../db/schema';
-import { saveDocument } from '../db/queries';
 import { Session } from 'next-auth';
 
 export interface SaveDocumentProps {
@@ -56,6 +55,7 @@ export function createDocumentHandler<T extends ArtifactKind>(config: {
       });
 
       if (args.session?.user?.id) {
+        const { saveDocument } = await import('../db/queries');
         await saveDocument({
           id: args.id,
           title: args.title,
@@ -77,6 +77,7 @@ export function createDocumentHandler<T extends ArtifactKind>(config: {
       });
 
       if (args.session?.user?.id) {
+        const { saveDocument } = await import('../db/queries');
         await saveDocument({
           id: args.document.id,
           title: args.document.title,


### PR DESCRIPTION
## Summary
- fetch webset data from Crustdata instead of generating demo CSV
- document Crustdata token usage for webset
- load db helper lazily for artifact handlers

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aafb6c482c832483e91ec4a064d57e