### PR TITLE
feat: switch default model to gpt-5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,13 @@ export function getProvider(apiKey?: string) {
       })
     : customProvider({
         languageModels: {
-          'chat-model': openai('gpt-4o-mini', { apiKey }),
+          'chat-model': openai('gpt-5', { apiKey }),
           'chat-model-reasoning': wrapLanguageModel({
             model: openai('o4-mini', { apiKey }),
             middleware: extractReasoningMiddleware({ tagName: 'think' }),
           }),
-          'title-model': openai('gpt-4o-mini', { apiKey }),
-          'artifact-model': openai('gpt-4o-mini', { apiKey }),
+          'title-model': openai('gpt-5', { apiKey }),
+          'artifact-model': openai('gpt-5', { apiKey }),
         },
         imageModels: { 'small-model': openai.image('gpt-image-1', { apiKey }) },
       });

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## Model Providers
 
-This template ships with [OpenAI](https://openai.com) `gpt-4o-mini` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
+This template ships with [OpenAI](https://openai.com) `gpt-5` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
 
 In the chat header you can enter your own OpenAI API key, which will be used for chat responses and artifact generation.
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -29,13 +29,13 @@ export function getProvider(apiKey?: string) {
 
   return customProvider({
     languageModels: {
-      'chat-model': openai('gpt-4o-mini'),
+      'chat-model': openai('gpt-5'),
       'chat-model-reasoning': wrapLanguageModel({
         model: openai('o4-mini'),
         middleware: extractReasoningMiddleware({ tagName: 'think' }),
       }),
-      'title-model': openai('gpt-4o-mini'),
-      'artifact-model': openai('gpt-4o-mini'),
+      'title-model': openai('gpt-5'),
+      'artifact-model': openai('gpt-5'),
     },
     imageModels: {
       'small-model': openai.image('gpt-image-1'),


### PR DESCRIPTION
## Summary
- default to `gpt-5` for chat, title, and artifact models
- document new `gpt-5` default model

## Testing
- `pnpm exec next lint`
- `pnpm exec biome lint AGENTS.md README.md lib/ai/providers.ts`
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab07dbcb908324b91136236e1e1fd0