### PR TITLE
Add hardcoded Bangalore startups webset

### DIFF
--- a/artifacts/webset/server.ts
+++ b/artifacts/webset/server.ts
@@ -3,11 +3,19 @@ import { websetPrompt, updateDocumentPrompt } from '@/lib/ai/prompts';
 import { createDocumentHandler } from '@/lib/artifacts/server';
 import { streamObject } from 'ai';
 import { z } from 'zod';
+import { generateBangaloreCSV } from '@/lib/data/bangalore-startups';
 
 export const websetDocumentHandler = createDocumentHandler<'webset'>({
   kind: 'webset',
   onCreateDocument: async ({ title, dataStream, apiKey }) => {
     let draftContent = '';
+
+    const normalizedTitle = title.toLowerCase();
+    if (normalizedTitle.includes('startups in bangalore')) {
+      draftContent = generateBangaloreCSV();
+      dataStream.writeData({ type: 'sheet-delta', content: draftContent });
+      return draftContent;
+    }
 
     const provider = getProvider(apiKey);
     const { fullStream } = streamObject({

--- a/lib/data/bangalore-startups.ts
+++ b/lib/data/bangalore-startups.ts
@@ -1,0 +1,233 @@
+export interface BangaloreCompany {
+  company_name: string;
+  year_founded: string;
+  location: string;
+  last_funding_round_type: string;
+  last_funding_amount_usd: number;
+  last_funding_date: string;
+}
+
+export const bangaloreCompanies: BangaloreCompany[] = [
+  {
+    company_name: "Meesho",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SECONDARY_MARKET",
+    last_funding_amount_usd: 260000000,
+    last_funding_date: "2025-01-01"
+  },
+  {
+    company_name: "Myntra",
+    year_founded: "2007",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "UNDISCLOSED",
+    last_funding_amount_usd: 124479401,
+    last_funding_date: "2025-05-01"
+  },
+  {
+    company_name: "Udaan",
+    year_founded: "2016",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_G",
+    last_funding_amount_usd: 114000000,
+    last_funding_date: "2025-02-01"
+  },
+  {
+    company_name: "Ola Electric",
+    year_founded: "2017",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "POST_IPO_SECONDARY",
+    last_funding_amount_usd: 80429080,
+    last_funding_date: "2025-06-01"
+  },
+  {
+    company_name: "Shadowfax",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_UNKNOWN",
+    last_funding_amount_usd: 3000000,
+    last_funding_date: "2025-03-01"
+  },
+  {
+    company_name: "Livspace",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "UNDISCLOSED",
+    last_funding_amount_usd: 50131668,
+    last_funding_date: "2025-04-01"
+  },
+  {
+    company_name: "Hindustan Coca-Cola Beverages",
+    year_founded: "1997",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "DEBT_FINANCING",
+    last_funding_amount_usd: 300000000,
+    last_funding_date: "2024-12-01"
+  },
+  {
+    company_name: "Rapido",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_E",
+    last_funding_amount_usd: 14603658,
+    last_funding_date: "2025-06-01"
+  },
+  {
+    company_name: "Porter",
+    year_founded: "2014",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_F",
+    last_funding_amount_usd: 200000000,
+    last_funding_date: "2025-05-01"
+  },
+  {
+    company_name: "Medi Assist",
+    year_founded: "2002",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "POST_IPO_SECONDARY",
+    last_funding_amount_usd: 72792245,
+    last_funding_date: "2024-09-01"
+  },
+  {
+    company_name: "HomeLane",
+    year_founded: "2014",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_UNKNOWN",
+    last_funding_amount_usd: 26884818,
+    last_funding_date: "2024-09-01"
+  },
+  {
+    company_name: "K-12 Techno Services",
+    year_founded: "2010",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SECONDARY_MARKET",
+    last_funding_amount_usd: 40075688,
+    last_funding_date: "2024-12-01"
+  },
+  {
+    company_name: "Cred",
+    year_founded: "2018",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_UNKNOWN",
+    last_funding_amount_usd: 72071451,
+    last_funding_date: "2025-06-01"
+  },
+  {
+    company_name: "Bluestone.com",
+    year_founded: "2011",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "DEBT_FINANCING",
+    last_funding_amount_usd: 4691071,
+    last_funding_date: "2025-05-01"
+  },
+  {
+    company_name: "HealthifyMe Wellness",
+    year_founded: "2012",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_D",
+    last_funding_amount_usd: 20000000,
+    last_funding_date: "2024-10-01"
+  },
+  {
+    company_name: "slice",
+    year_founded: "2016",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "UNDISCLOSED",
+    last_funding_amount_usd: 8530733,
+    last_funding_date: "2024-10-01"
+  },
+  {
+    company_name: "Jumbotail",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_D",
+    last_funding_amount_usd: 120000000,
+    last_funding_date: "2025-06-01"
+  },
+  {
+    company_name: "ZoomCar",
+    year_founded: "2012",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "POST_IPO_EQUITY",
+    last_funding_amount_usd: 9150000,
+    last_funding_date: "2024-11-01"
+  },
+  {
+    company_name: "Leap",
+    year_founded: "2019",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "DEBT_FINANCING",
+    last_funding_amount_usd: 99928090,
+    last_funding_date: "2025-03-01"
+  },
+  {
+    company_name: "Ace Designers Limited",
+    year_founded: "1979",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "PRIVATE_EQUITY",
+    last_funding_amount_usd: 141883382,
+    last_funding_date: "2025-04-01"
+  },
+  {
+    company_name: "GIVA",
+    year_founded: "2019",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_B",
+    last_funding_amount_usd: 5956998,
+    last_funding_date: "2025-03-01"
+  },
+  {
+    company_name: "Money View",
+    year_founded: "2014",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_UNKNOWN",
+    last_funding_amount_usd: 4604201,
+    last_funding_date: "2024-09-01"
+  },
+  {
+    company_name: "Cashfree Payments",
+    year_founded: "2015",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_C",
+    last_funding_amount_usd: 53000000,
+    last_funding_date: "2025-02-01"
+  },
+  {
+    company_name: "MEDGENOME",
+    year_founded: "2013",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "SERIES_E",
+    last_funding_amount_usd: 47500000,
+    last_funding_date: "2025-07-01"
+  },
+  {
+    company_name: "Yulu",
+    year_founded: "2017",
+    location: "Bengaluru, Karnataka, India",
+    last_funding_round_type: "CORPORATE_ROUND",
+    last_funding_amount_usd: 2919866,
+    last_funding_date: "2025-07-01"
+  }
+] as const;
+
+export function generateBangaloreCSV(): string {
+  const headers = [
+    "Company Name",
+    "Year Founded",
+    "Location",
+    "Last Funding Round",
+    "Last Funding Amount (USD)",
+    "Last Funding Date",
+  ];
+  const rows = bangaloreCompanies.map((c) => [
+    c.company_name,
+    c.year_founded,
+    c.location,
+    c.last_funding_round_type,
+    String(c.last_funding_amount_usd),
+    c.last_funding_date,
+  ]);
+  return [headers, ...rows]
+    .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(","))
+    .join("\n");
+}

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -1,4 +1,8 @@
-import 'server-only';
+// Prevent server-only from throwing during tests
+if (process.env.NODE_ENV !== 'test') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('server-only');
+}
 
 import {
   and,

--- a/tests/routes/webset.test.ts
+++ b/tests/routes/webset.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../fixtures';
 import { artifactKinds, documentHandlersByArtifactKind } from '@/lib/artifacts/server';
+import { generateBangaloreCSV } from '@/lib/data/bangalore-startups';
 
 // Ensure webset artifact is registered
 
@@ -11,5 +12,13 @@ test.describe('webset artifact registration', () => {
   test('document handlers include webset handler', async () => {
     const hasWebset = documentHandlersByArtifactKind.some(h => h.kind === 'webset');
     expect(hasWebset).toBeTruthy();
+  });
+});
+
+test.describe('bangalore startups dataset', () => {
+  test('csv includes at least 20 profiles', async () => {
+    const csv = generateBangaloreCSV();
+    const lines = csv.trim().split('\n');
+    expect(lines.length - 1).toBeGreaterThanOrEqual(20);
   });
 });


### PR DESCRIPTION
## Summary
- Provide hardcoded dataset of 25 Bangalore startups and utility to export as CSV
- Return this dataset when the user requests startups in Bangalore via the webset document handler
- Ensure tests cover dataset size and allow server-side modules to run in tests

## Testing
- `NODE_ENV=test pnpm test tests/routes/webset.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab0bbac618832489d2b4b9fdac370c