### PR TITLE
feat: add landing page and move chat route

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const redirectUrl = searchParams.get('redirectUrl') || '/';
+  const redirectUrl = searchParams.get('redirectUrl') || '/chat';
 
   const token = await getToken({
     req: request,
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
   });
 
   if (token) {
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(new URL('/chat', request.url));
   }
 
   return signIn('guest', { redirect: true, redirectTo: redirectUrl });

--- a/app/(auth)/auth.config.ts
+++ b/app/(auth)/auth.config.ts
@@ -3,7 +3,7 @@ import type { NextAuthConfig } from 'next-auth';
 export const authConfig = {
   pages: {
     signIn: '/login',
-    newUser: '/',
+    newUser: '/chat',
   },
   providers: [
     // added later in auth.ts since it requires bcrypt which is only compatible with Node.js

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -40,6 +40,7 @@ export default function Page() {
     } else if (state.status === 'success') {
       setIsSuccessful(true);
       updateSession();
+      router.push('/chat');
       router.refresh();
     }
   }, [state.status, updateSession, router]);

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -41,6 +41,7 @@ export default function Page() {
 
       setIsSuccessful(true);
       updateSession();
+      router.push('/chat');
       router.refresh();
     }
   }, [state.status, updateSession, router]);

--- a/app/(chat)/api/gmail/callback/route.ts
+++ b/app/(chat)/api/gmail/callback/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   jar.delete(VERIFIER_COOKIE);
 
   if (!sessionId) {
-    return NextResponse.redirect(new URL('/?error=no-session', request.url));
+    return NextResponse.redirect(new URL('/chat?error=no-session', request.url));
   }
 
   const url = new URL(request.url);
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
   const hasCode = url.searchParams.has('code');
 
   if (!stateCookie || !verifier || !hasCode || returnedState !== stateCookie) {
-    return NextResponse.redirect(new URL('/?error=invalid_state', request.url));
+    return NextResponse.redirect(new URL('/chat?error=invalid_state', request.url));
   }
 
   try {
@@ -64,9 +64,9 @@ export async function GET(request: NextRequest) {
     if (tokens.id_token) jar.set('gc_id_token', tokens.id_token, cookieOptions);
     if (tokens.expires_at) jar.set('gc_expires_at', String(tokens.expires_at), cookieOptions);
 
-    return NextResponse.redirect(new URL('/?connected=1', request.url));
+    return NextResponse.redirect(new URL('/chat?connected=1', request.url));
   } catch {
-    return NextResponse.redirect(new URL('/?error=oauth_failed', request.url));
+    return NextResponse.redirect(new URL('/chat?error=oauth_failed', request.url));
   }
 }
 

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -4,7 +4,7 @@ import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
 import { generateUUID } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
-import { auth } from '../(auth)/auth';
+import { auth } from '../../(auth)/auth';
 import { redirect } from 'next/navigation';
 
 export default async function Page() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+import { Button } from '@/components/ui/button';
+
+export default function Page() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-16 p-8 text-center">
+      <motion.section
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="flex flex-col items-center gap-6"
+      >
+        <h1 className="text-4xl font-bold">Cerch Ai</h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Unify your personal knowledge and company data in a single stylish
+          chat experience.
+        </p>
+        <Button asChild size="lg" className="mt-4">
+          <Link href="/chat">Try Demo</Link>
+        </Button>
+      </motion.section>
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.6 }}
+        className="grid w-full max-w-4xl grid-cols-1 gap-6 md:grid-cols-3"
+      >
+        <div className="rounded-xl border bg-background p-6 shadow-sm">
+          <h3 className="mb-2 text-xl font-semibold">Personal</h3>
+          <p className="text-sm text-muted-foreground">
+            Plan trips, summarise articles, and manage your day with an AI
+            companion.
+          </p>
+        </div>
+        <div className="rounded-xl border bg-background p-6 shadow-sm">
+          <h3 className="mb-2 text-xl font-semibold">Team</h3>
+          <p className="text-sm text-muted-foreground">
+            Share project context, brainstorm ideas, and collaborate in real
+            time.
+          </p>
+        </div>
+        <div className="rounded-xl border bg-background p-6 shadow-sm">
+          <h3 className="mb-2 text-xl font-semibold">Company Data</h3>
+          <p className="text-sm text-muted-foreground">
+            Explore documents, spreadsheets, and knowledge bases with natural
+            language.
+          </p>
+        </div>
+      </motion.section>
+    </main>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -46,7 +46,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                   className="p-2 h-fit"
                   onClick={() => {
                     setOpenMobile(false);
-                    router.push('/');
+                    router.push('/chat');
                     router.refresh();
                   }}
                 >

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -36,7 +36,7 @@ function PureChatHeader({
               variant="outline"
               className="order-2 md:order-1 md:px-2 px-2 md:h-fit ml-auto md:ml-0"
               onClick={() => {
-                router.push('/');
+                router.push('/chat');
                 router.refresh();
               }}
             >

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -144,7 +144,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
     setShowDeleteDialog(false);
 
     if (deleteId === id) {
-      router.push('/');
+      router.push('/chat');
     }
   };
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,17 +24,24 @@ export async function middleware(request: NextRequest) {
   });
 
   if (!token) {
-    const redirectUrl = encodeURIComponent(request.url);
+    if (
+      pathname.startsWith('/chat') ||
+      (pathname.startsWith('/api') && !pathname.startsWith('/api/auth'))
+    ) {
+      const redirectUrl = encodeURIComponent(request.url);
 
-    return NextResponse.redirect(
-      new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url),
-    );
+      return NextResponse.redirect(
+        new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url),
+      );
+    }
+
+    return NextResponse.next();
   }
 
   const isGuest = guestRegex.test(token?.email ?? '');
 
-  if (token && !isGuest && ['/login', '/register'].includes(pathname)) {
-    return NextResponse.redirect(new URL('/', request.url));
+  if (!isGuest && ['/login', '/register'].includes(pathname)) {
+    return NextResponse.redirect(new URL('/chat', request.url));
   }
 
   return NextResponse.next();
@@ -42,8 +49,7 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/',
-    '/chat/:id',
+    '/chat/:path*',
     '/api/:path*',
     '/login',
     '/register',

--- a/tests/e2e/session.test.ts
+++ b/tests/e2e/session.test.ts
@@ -9,7 +9,7 @@ test.describe
     test('Authenticate as guest user when a new session is loaded', async ({
       page,
     }) => {
-      const response = await page.goto('/');
+      const response = await page.goto('/chat');
 
       if (!response) {
         throw new Error('Failed to load page');
@@ -25,14 +25,14 @@ test.describe
       }
 
       expect(chain).toEqual([
-        'http://localhost:3000/',
-        'http://localhost:3000/api/auth/guest?redirectUrl=http%3A%2F%2Flocalhost%3A3000%2F',
-        'http://localhost:3000/',
+        'http://localhost:3000/chat',
+        'http://localhost:3000/api/auth/guest?redirectUrl=http%3A%2F%2Flocalhost%3A3000%2Fchat',
+        'http://localhost:3000/chat',
       ]);
     });
 
     test('Log out is not available for guest users', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/chat');
 
       const sidebarToggleButton = page.getByTestId('sidebar-toggle-button');
       await sidebarToggleButton.click();
@@ -51,7 +51,7 @@ test.describe
     test('Do not authenticate as guest user when an existing non-guest session is active', async ({
       adaContext,
     }) => {
-      const response = await adaContext.page.goto('/');
+      const response = await adaContext.page.goto('/chat');
 
       if (!response) {
         throw new Error('Failed to load page');
@@ -66,7 +66,7 @@ test.describe
         request = request.redirectedFrom();
       }
 
-      expect(chain).toEqual(['http://localhost:3000/']);
+      expect(chain).toEqual(['http://localhost:3000/chat']);
     });
 
     test('Allow navigating to /login as guest user', async ({ page }) => {
@@ -82,7 +82,7 @@ test.describe
     });
 
     test('Do not show email in user menu for guest user', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/chat');
 
       const sidebarToggleButton = page.getByTestId('sidebar-toggle-button');
       await sidebarToggleButton.click();
@@ -115,14 +115,14 @@ test.describe
     test('Log into account that exists', async ({ page }) => {
       await authPage.login(testUser.email, testUser.password);
 
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
       await expect(page.getByPlaceholder('Send a message...')).toBeVisible();
     });
 
     test('Display user email in user menu', async ({ page }) => {
       await authPage.login(testUser.email, testUser.password);
 
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
       await expect(page.getByPlaceholder('Send a message...')).toBeVisible();
 
       const userEmail = await page.getByTestId('user-email');
@@ -137,13 +137,13 @@ test.describe
       page,
     }) => {
       await authPage.login(testUser.email, testUser.password);
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
 
       const userEmail = await page.getByTestId('user-email');
       await expect(userEmail).toHaveText(testUser.email);
 
       await page.goto('/api/auth/guest');
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
 
       const updatedUserEmail = await page.getByTestId('user-email');
       await expect(updatedUserEmail).toHaveText(testUser.email);
@@ -151,7 +151,7 @@ test.describe
 
     test('Log out is available for non-guest users', async ({ page }) => {
       await authPage.login(testUser.email, testUser.password);
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
 
       authPage.openSidebar();
 
@@ -170,18 +170,18 @@ test.describe
       page,
     }) => {
       await authPage.login(testUser.email, testUser.password);
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
 
       await page.goto('/register');
-      await expect(page).toHaveURL('/');
+      await expect(page).toHaveURL('/chat');
     });
 
     test('Do not navigate to /login for non-guest users', async ({ page }) => {
       await authPage.login(testUser.email, testUser.password);
-      await page.waitForURL('/');
+      await page.waitForURL('/chat');
 
       await page.goto('/login');
-      await expect(page).toHaveURL('/');
+      await expect(page).toHaveURL('/chat');
     });
   });
 

--- a/tests/pages/auth.ts
+++ b/tests/pages/auth.ts
@@ -34,7 +34,7 @@ export class AuthPage {
 
   async logout(email: string, password: string) {
     await this.login(email, password);
-    await this.page.waitForURL('/');
+    await this.page.waitForURL('/chat');
 
     await this.openSidebar();
 

--- a/tests/pages/chat.ts
+++ b/tests/pages/chat.ts
@@ -27,7 +27,7 @@ export class ChatPage {
   }
 
   async createNewChat() {
-    await this.page.goto('/');
+    await this.page.goto('/chat');
   }
 
   public getCurrentURL(): string {


### PR DESCRIPTION
## Summary
- add animated marketing landing page with try demo CTA
- move chat interface to /chat and update auth redirects
- adjust middleware and tests for new routing

## Testing
- `pnpm lint` (fails: Forbidden non-null assertion / static element interactions)
- `pnpm test` (fails: This module cannot be imported from a Client Component module)


------
https://chatgpt.com/codex/tasks/task_e_68b05c731f5083249aaf05e5eb5a3550