### PR TITLE
feat: add landing page and chat route

### DIFF
--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -4,7 +4,7 @@ import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
 import { generateUUID } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
-import { auth } from '../(auth)/auth';
+import { auth } from '../../(auth)/auth';
 import { redirect } from 'next/navigation';
 
 export default async function Page() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Briefcase, FileSearch, Users, Database } from 'lucide-react';
+
+const features = [
+  {
+    icon: FileSearch,
+    title: 'Instant Answers',
+    description:
+      'Ask questions across documents, sheets, and wikis and get answers in seconds.',
+  },
+  {
+    icon: Users,
+    title: 'Team Knowledge',
+    description:
+      'Share conversations and insights so everyone stays on the same page.',
+  },
+  {
+    icon: Briefcase,
+    title: 'Customer Support',
+    description:
+      'Resolve customer issues quickly with access to internal guides and history.',
+  },
+  {
+    icon: Database,
+    title: 'Company Data',
+    description:
+      'Connect your structured data sources to chat with your numbers naturally.',
+  },
+];
+
+export default function LandingPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <section className="flex flex-col items-center justify-center flex-1 px-4 py-24 text-center gap-6 bg-gradient-to-b from-background to-muted">
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-5xl font-bold tracking-tight"
+        >
+          Cerch AI
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.6 }}
+          className="max-w-2xl text-lg text-muted-foreground"
+        >
+          AI that understands your people and company data so you can work
+          smarter.
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.6 }}
+        >
+          <Button asChild size="lg">
+            <Link href="/chat">Try Demo</Link>
+          </Button>
+        </motion.div>
+      </section>
+
+      <section className="py-24 bg-background">
+        <div className="max-w-5xl mx-auto px-4 grid gap-8 md:grid-cols-2">
+          {features.map((feature, idx) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: idx * 0.1, duration: 0.5 }}
+            >
+              <Card className="h-full">
+                <CardHeader className="space-y-2">
+                  <feature.icon className="h-8 w-8 text-primary" />
+                  <CardTitle>{feature.title}</CardTitle>
+                  <CardDescription>{feature.description}</CardDescription>
+                </CardHeader>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -46,7 +46,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                   className="p-2 h-fit"
                   onClick={() => {
                     setOpenMobile(false);
-                    router.push('/');
+                      router.push('/chat');
                     router.refresh();
                   }}
                 >

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -36,7 +36,7 @@ function PureChatHeader({
               variant="outline"
               className="order-2 md:order-1 md:px-2 px-2 md:h-fit ml-auto md:ml-0"
               onClick={() => {
-                router.push('/');
+                router.push('/chat');
                 router.refresh();
               }}
             >

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -144,7 +144,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
     setShowDeleteDialog(false);
 
     if (deleteId === id) {
-      router.push('/');
+      router.push('/chat');
     }
   };
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,6 +17,10 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  if (pathname === '/') {
+    return NextResponse.next();
+  }
+
   const token = await getToken({
     req: request,
     secret: process.env.AUTH_SECRET,
@@ -42,7 +46,7 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/',
+    '/chat',
     '/chat/:id',
     '/api/:path*',
     '/login',


### PR DESCRIPTION
## Summary
- add animated landing page with CTA to chat
- move chat interface to `/chat`
- update navigation and middleware for new route

## Testing
- `npx next lint --file app/page.tsx --file components/app-sidebar.tsx --file components/chat-header.tsx --file components/sidebar-history.tsx --file "app/(chat)/chat/page.tsx" --file middleware.ts` *(TypeScript version warning)*
- `pnpm exec biome lint app/page.tsx components/app-sidebar.tsx components/chat-header.tsx components/sidebar-history.tsx app/(chat)/chat/page.tsx middleware.ts`
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68b05c731f5083249aaf05e5eb5a3550