### PR TITLE
feat: add landing transition and chat links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,40 @@
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Spline from '@splinetool/react-spline/next';
 import { Button } from '@/components/ui/button';
 
 export default function Home() {
+  const [transitioning, setTransitioning] = useState(false);
+  const router = useRouter();
+
+  const startTransition = () => {
+    if (transitioning) return;
+    setTransitioning(true);
+    setTimeout(() => {
+      router.push('/landing.html');
+    }, 700);
+  };
+
+  useEffect(() => {
+    const handleWheel = () => startTransition();
+    window.addEventListener('wheel', handleWheel, { once: true });
+    return () => window.removeEventListener('wheel', handleWheel);
+  }, [transitioning]);
+
   return (
-    <main className="relative h-screen w-screen">
+    <main
+      className={`relative h-screen w-screen transition-opacity duration-700 ${
+        transitioning ? 'opacity-0' : 'opacity-100'
+      }`}
+      onWheel={startTransition}
+    >
       <Spline scene="https://prod.spline.design/DS0UgrDOifhNt9T6/scene.splinecode" />
       <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
         <Button
-          asChild
+          onClick={startTransition}
           className="bg-[hsl(246,82%,60%)] text-white hover:opacity-90"
         >
-          <Link href="/login">cerch now</Link>
+          cerch now
         </Button>
       </div>
     </main>

--- a/landing.html
+++ b/landing.html
@@ -110,10 +110,10 @@ animation: countUp 0.8s ease-out forwards;
                 </nav>
                 
                 <div class="hidden md:flex items-center gap-3">
-                    <button class="px-4 py-2 text-sm text-white/70 hover:text-white transition-colors">Sign In</button>
-                    <button class="px-4 py-2 text-sm bg-white text-black rounded-full hover:bg-white/90 transition-all transform hover:scale-105">
+                    <a href="/login" class="px-4 py-2 text-sm text-white/70 hover:text-white transition-colors">Sign In</a>
+                    <a href="/chat" class="px-4 py-2 text-sm bg-white text-black rounded-full hover:bg-white/90 transition-all transform hover:scale-105">
                         Try Cerch Free
-                    </button>
+                    </a>
                 </div>
                 
                 <button class="md:hidden p-2">
@@ -181,22 +181,25 @@ animation: countUp 0.8s ease-out forwards;
                                 .icon-box svg { width: 20px; height: 20px; stroke: currentColor; }
                             </style>
                         
-                            <button class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
+                            <a href="/chat" class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
                             <span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
                             </span>
                             Generate my first list
-                          </button>
-                        
+                          </a>
+
                             <script>
-                                const btn = document.querySelector('.glow-btn');
-                          btn.addEventListener('mousemove', (e) => {
-                            const rect = btn.getBoundingClientRect();
-                            const x = e.clientX - rect.left;
-                            const y = e.clientY - rect.top;
-                            btn.style.setProperty('--x', x + 'px');
-                            btn.style.setProperty('--y', y + 'px');
-                          });
+                                window.addEventListener('DOMContentLoaded', () => {
+                                  document.querySelectorAll('.glow-btn').forEach((btn) => {
+                                    btn.addEventListener('mousemove', (e) => {
+                                      const rect = btn.getBoundingClientRect();
+                                      const x = e.clientX - rect.left;
+                                      const y = e.clientY - rect.top;
+                                      btn.style.setProperty('--x', x + 'px');
+                                      btn.style.setProperty('--y', y + 'px');
+                                    });
+                                  });
+                                });
                             </script>
                     
                     <button class="hover:bg-white/30 transition-all flex gap-2 font-medium bg-[#000000] border-white/20 border rounded-full pt-4 pr-8 pb-4 pl-8 items-center">
@@ -778,9 +781,9 @@ animation: countUp 0.8s ease-out forwards;
                     Describe who you need. Cerch AI returns verified, deduped, enriched, and scored results. Export, API, and alerts included.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <button class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
+                    <a href="/chat" class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
-                            </span></button>
+                            </span></a>
                     <button class="px-8 py-4 border border-white/30 rounded-full font-semibold hover:bg-white/10 transition-all flex items-center gap-2 justify-center">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" data-lucide="phone" class="lucide lucide-phone h-5 w-5"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"></path></svg>
                         Schedule a Call


### PR DESCRIPTION
## Summary
- fade out initial Spline page and route to landing.html on scroll or button click
- link landing page actions to login/chat and support glow buttons

## Testing
- `pnpm format app/page.tsx`
- `pnpm exec biome lint app/page.tsx`
- `pnpm lint` *(fails: Do not shadow the global "escape" property, Forbidden non-null assertion)*
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb30f2ebc8324bfc207d8f6cbfaa8