### PR TITLE
feat: add animated landing flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,40 @@
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import Spline from '@splinetool/react-spline/next';
 import { Button } from '@/components/ui/button';
 
 export default function Home() {
+  const [showLanding, setShowLanding] = useState(false);
+
+  useEffect(() => {
+    const handleWheel = () => setShowLanding(true);
+    window.addEventListener('wheel', handleWheel, { once: true });
+    return () => window.removeEventListener('wheel', handleWheel);
+  }, []);
+
   return (
-    <main className="relative h-screen w-screen">
-      <Spline scene="https://prod.spline.design/DS0UgrDOifhNt9T6/scene.splinecode" />
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
-        <Button
-          asChild
-          className="bg-[hsl(246,82%,60%)] text-white hover:opacity-90"
-        >
-          <Link href="/login">cerch now</Link>
-        </Button>
-      </div>
+    <main className="relative h-screen w-screen overflow-hidden">
+      <section
+        className={`absolute inset-0 transition-all duration-700 ${showLanding ? 'opacity-0 -translate-y-10 pointer-events-none' : 'opacity-100 translate-y-0'}`}
+      >
+        <Spline scene="https://prod.spline.design/DS0UgrDOifhNt9T6/scene.splinecode" />
+        <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
+          <Button
+            onClick={() => setShowLanding(true)}
+            className="bg-[hsl(246,82%,60%)] text-white hover:opacity-90"
+          >
+            search now
+          </Button>
+        </div>
+      </section>
+      <section
+        className={`absolute inset-0 transition-all duration-700 ${showLanding ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10 pointer-events-none'}`}
+      >
+        <iframe
+          src="/landing/index.html"
+          title="Cerch landing"
+          className="h-full w-full border-none"
+        />
+      </section>
     </main>
   );
 }

--- a/docs/prd/landing-page-flow.md
+++ b/docs/prd/landing-page-flow.md
@@ -1,0 +1,33 @@
+# Landing Page Flow
+
+## Context
+The current home page goes directly to login via a button. A new animated landing page has been added and should appear after initial interaction with the hero page.
+
+## Goals
+- Introduce an intermediate landing experience with animations.
+- Allow users to reach the chat/login flow via calls to action.
+
+## Non-goals
+- Redesign chat or auth flows.
+
+## Scope & Assumptions
+- Animation triggered by scroll or button click.
+- Landing page hosted as static HTML under `/public/landing`.
+
+## Approach
+- Embed the HTML landing page via an iframe and transition between sections using CSS animations.
+- Update landing page buttons to link to `/login`.
+
+## Impacted Areas
+- `app/page.tsx`
+- `public/landing/index.html`
+
+## Validation
+- Manual check that the transition runs and CTA links open the login page.
+
+## Rollout/Rollback
+- Rollout with standard deployment.
+- Revert commit to rollback.
+
+## Links
+- PR: TODO

--- a/public/landing/index.html
+++ b/public/landing/index.html
@@ -110,10 +110,10 @@ animation: countUp 0.8s ease-out forwards;
                 </nav>
                 
                 <div class="hidden md:flex items-center gap-3">
-                    <button class="px-4 py-2 text-sm text-white/70 hover:text-white transition-colors">Sign In</button>
-                    <button class="px-4 py-2 text-sm bg-white text-black rounded-full hover:bg-white/90 transition-all transform hover:scale-105">
+                    <a href="/login" class="px-4 py-2 text-sm text-white/70 hover:text-white transition-colors">Sign In</a>
+                    <a href="/login" class="px-4 py-2 text-sm bg-white text-black rounded-full hover:bg-white/90 transition-all transform hover:scale-105">
                         Try Cerch Free
-                    </button>
+                    </a>
                 </div>
                 
                 <button class="md:hidden p-2">
@@ -181,15 +181,16 @@ animation: countUp 0.8s ease-out forwards;
                                 .icon-box svg { width: 20px; height: 20px; stroke: currentColor; }
                             </style>
                         
-                            <button class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
+                            <a href="/login" class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
                             <span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
                             </span>
                             Generate my first list
-                          </button>
-                        
+                          </a>
+
                             <script>
-                                const btn = document.querySelector('.glow-btn');
+                                window.addEventListener('load', () => {
+                          document.querySelectorAll('.glow-btn').forEach((btn) => {
                           btn.addEventListener('mousemove', (e) => {
                             const rect = btn.getBoundingClientRect();
                             const x = e.clientX - rect.left;
@@ -197,6 +198,8 @@ animation: countUp 0.8s ease-out forwards;
                             btn.style.setProperty('--x', x + 'px');
                             btn.style.setProperty('--y', y + 'px');
                           });
+                          });
+                                });
                             </script>
                     
                     <button class="hover:bg-white/30 transition-all flex gap-2 font-medium bg-[#000000] border-white/20 border rounded-full pt-4 pr-8 pb-4 pl-8 items-center">
@@ -778,9 +781,9 @@ animation: countUp 0.8s ease-out forwards;
                     Describe who you need. Cerch AI returns verified, deduped, enriched, and scored results. Export, API, and alerts included.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <button class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
+                    <a href="/login" class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
-                            </span></button>
+                            </span></a>
                     <button class="px-8 py-4 border border-white/30 rounded-full font-semibold hover:bg-white/10 transition-all flex items-center gap-2 justify-center">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" data-lucide="phone" class="lucide lucide-phone h-5 w-5"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"></path></svg>
                         Schedule a Call


### PR DESCRIPTION
## Summary
- add animated transition from hero to landing page
- link landing page CTAs to `/login`
- document landing flow plan

## Testing
- `pnpm lint` *(fails: Do not shadow the global "escape" property; Forbidden non-null assertion; Static Elements should not be interactive)*
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb30f2ebc8324bfc207d8f6cbfaa8