### PR TITLE
fix: mark home page as client component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import Spline from '@splinetool/react-spline/next';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## Summary
- mark home page as client component to enable hooks and window usage

## Testing
- `pnpm lint` *(fails: Do not shadow the global "escape" property; Forbidden non-null assertion; Static Elements should not be interactive)*
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc33bee48324810e961fdb1f3e81