### PR TITLE
fix: mark home page as client component and allow landing route

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Spline from '@splinetool/react-spline/next';

--- a/lib/googleTokens.ts
+++ b/lib/googleTokens.ts
@@ -18,7 +18,8 @@ export async function getFreshAccessToken(): Promise<FreshTokens> {
   const tokenSet = getTokenSet(sessionId);
 
   let accessToken = jar.get('gc_access_token')?.value || tokenSet?.access_token;
-  let refreshToken = jar.get('gc_refresh_token')?.value || tokenSet?.refresh_token;
+  let refreshToken =
+    jar.get('gc_refresh_token')?.value || tokenSet?.refresh_token;
   const expiresAtStr =
     jar.get('gc_expires_at')?.value ||
     (tokenSet?.expires_at != null ? String(tokenSet.expires_at) : undefined);
@@ -26,16 +27,20 @@ export async function getFreshAccessToken(): Promise<FreshTokens> {
 
   const now = Date.now();
   const isExpiringSoon = expiresAt != null && now > expiresAt - EXPIRY_SKEW_MS;
-  const shouldRefresh = Boolean(refreshToken && (!accessToken || isExpiringSoon));
+  const shouldRefresh = Boolean(
+    refreshToken && (!accessToken || isExpiringSoon),
+  );
 
   if (shouldRefresh) {
     try {
       const config = await getGoogleClient();
-      const refreshed = await refreshTokenGrant(config, refreshToken!);
+      const refreshed = await refreshTokenGrant(config, refreshToken as string);
       accessToken = refreshed.access_token || accessToken;
       refreshToken = refreshed.refresh_token || refreshToken;
       expiresAt =
-        refreshed.expires_in != null ? now + refreshed.expires_in * 1000 : expiresAt;
+        refreshed.expires_in != null
+          ? now + refreshed.expires_in * 1000
+          : expiresAt;
 
       // Persist refreshed tokens
       const cookieOptions = {
@@ -46,7 +51,8 @@ export async function getFreshAccessToken(): Promise<FreshTokens> {
         maxAge: 60 * 60 * 24 * 7,
       };
       if (accessToken) jar.set('gc_access_token', accessToken, cookieOptions);
-      if (refreshToken) jar.set('gc_refresh_token', refreshToken, cookieOptions);
+      if (refreshToken)
+        jar.set('gc_refresh_token', refreshToken, cookieOptions);
       if (expiresAt) jar.set('gc_expires_at', String(expiresAt), cookieOptions);
       if (sessionId) {
         const existing = tokenSet || {};
@@ -64,4 +70,3 @@ export async function getFreshAccessToken(): Promise<FreshTokens> {
 
   return { accessToken, refreshToken, expiresAt };
 }
-

--- a/lib/providers/normalize.ts
+++ b/lib/providers/normalize.ts
@@ -1,26 +1,45 @@
 import type { Company, Person } from './types';
 
-export function toCSV(headers: string[], rows: Array<Record<string, any>>): string {
-  const escape = (v: any) => {
+export function toCSV(
+  headers: string[],
+  rows: Array<Record<string, any>>,
+): string {
+  const escapeCell = (v: any) => {
     const s = v == null ? '' : String(v);
     if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-      return '"' + s.replace(/"/g, '""') + '"';
+      return `"${s.replace(/"/g, '""')}"`;
     }
     return s;
   };
 
   const headerLine = headers.join(',');
-  const lines = rows.map((r) => headers.map((h) => escape(r[h])).join(','));
+  const lines = rows.map((r) => headers.map((h) => escapeCell(r[h])).join(','));
   return [headerLine, ...lines].join('\n');
 }
 
 export function normalizePeopleRows(rows: any[]): Person[] {
   return rows.map((r) => {
-    const currentEmp = Array.isArray(r.current_employers) && r.current_employers.length > 0 ? r.current_employers[0] : undefined;
-    const title = r.default_position_title || currentEmp?.title || r.title || r.role || r.job_title || '';
-    const company = currentEmp?.name || r.company || r.organization || r.employer || '';
-    const linkedin = r.linkedin_profile_url || r.flagship_profile_url || r.linkedin_url || r.linkedin || '';
-    const profileImg = r.profile_picture_url || r.profile_image_url || r.avatar || r.image || '';
+    const currentEmp =
+      Array.isArray(r.current_employers) && r.current_employers.length > 0
+        ? r.current_employers[0]
+        : undefined;
+    const title =
+      r.default_position_title ||
+      currentEmp?.title ||
+      r.title ||
+      r.role ||
+      r.job_title ||
+      '';
+    const company =
+      currentEmp?.name || r.company || r.organization || r.employer || '';
+    const linkedin =
+      r.linkedin_profile_url ||
+      r.flagship_profile_url ||
+      r.linkedin_url ||
+      r.linkedin ||
+      '';
+    const profileImg =
+      r.profile_picture_url || r.profile_image_url || r.avatar || r.image || '';
     const description = r.headline || r.summary || r.description || '';
     const location = r.region || r.location || r.city || '';
 
@@ -42,20 +61,39 @@ export function normalizePeopleRows(rows: any[]): Person[] {
 export function normalizeCompanyRows(rows: any[]): Company[] {
   return rows.map((r) => {
     const name = r.company_name || r.name || '';
-    const industries = r.taxonomy?.linkedin_industries || r.industries || r.industry;
-    const industry = Array.isArray(industries) ? industries.join(', ') : industries || '';
-    const website = r.company_website || (r.company_website_domain ? `https://${r.company_website_domain}` : '') || r.website || r.url || '';
-    const location = r.headquarters || r.hq_country || r.largest_headcount_country || r.location || '';
+    const industries =
+      r.taxonomy?.linkedin_industries || r.industries || r.industry;
+    const industry = Array.isArray(industries)
+      ? industries.join(', ')
+      : industries || '';
+    const website =
+      r.company_website ||
+      (r.company_website_domain ? `https://${r.company_website_domain}` : '') ||
+      r.website ||
+      r.url ||
+      '';
+    const location =
+      r.headquarters ||
+      r.hq_country ||
+      r.largest_headcount_country ||
+      r.location ||
+      '';
     const size = r.linkedin_headcount || r.headcount || '';
-    const funding = r.crunchbase_total_investment_usd || r.last_funding_round_investment_usd || r.funding || '';
-    const logo_url = r.linkedin_logo_url || r.logo_url || r.logo || r.image || '';
+    const funding =
+      r.crunchbase_total_investment_usd ||
+      r.last_funding_round_investment_usd ||
+      r.funding ||
+      '';
+    const logo_url =
+      r.linkedin_logo_url || r.logo_url || r.logo || r.image || '';
     const description = r.linkedin_company_description || r.description || '';
 
     return {
       name,
       industry,
       company_url: website,
-      linkedin_url: r.linkedin_profile_url || r.linkedin_url || r.linkedin || '',
+      linkedin_url:
+        r.linkedin_profile_url || r.linkedin_url || r.linkedin || '',
       location,
       size,
       funding,

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,13 +24,17 @@ export async function middleware(request: NextRequest) {
   });
 
   // Block any legacy guest sessions (email like guest-<ts>)
-  if (token && typeof (token as any).email === 'string' && /^guest-\d+$/.test((token as any).email as string)) {
+  if (
+    token &&
+    typeof (token as any).email === 'string' &&
+    /^guest-\d+$/.test((token as any).email as string)
+  ) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
   if (!token) {
-    // Allow public access to home, login, && register without forcing guest auth
-    if (['/', '/login', '/register'].includes(pathname)) {
+    // Allow public access to home, landing page, login, && register without forcing guest auth
+    if (['/', '/landing.html', '/login', '/register'].includes(pathname)) {
       return NextResponse.next();
     }
     return NextResponse.redirect(new URL('/login', request.url));


### PR DESCRIPTION
## Summary
- mark home page as a client component so router hooks compile
- allow unauthenticated users to reach landing page and clean up lint issues

## Testing
- `pnpm lint`
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc7963288324b50958b1958021ce