### PR TITLE
feat: replace landing page with static HTML

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,5 @@
-import Link from 'next/link';
-import Spline from '@splinetool/react-spline/next';
-import { Button } from '@/components/ui/button';
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return (
-    <main className="relative h-screen w-screen">
-      <Spline scene="https://prod.spline.design/DS0UgrDOifhNt9T6/scene.splinecode" />
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
-        <Button
-          asChild
-          className="bg-[hsl(246,82%,60%)] text-white hover:opacity-90"
-        >
-          <Link href="/login">cerch now</Link>
-        </Button>
-      </div>
-    </main>
-  );
+  redirect('/landingpage.html');
 }

--- a/docs/prd/landing-page-replacement.md
+++ b/docs/prd/landing-page-replacement.md
@@ -1,0 +1,43 @@
+# Landing Page Replacement PRD
+
+## Context
+The existing landing page is a minimal Spline demo. A richer landing page exists in `landingpage.html` with animations and marketing copy. We want this new page to serve as the site's entry point.
+
+## Goals
+- Serve `landingpage.html` when users visit `/`.
+- Ensure primary call‑to‑action buttons navigate to the chat window.
+
+## Non-goals
+- Redesign of chat or authentication flows.
+- Copy or design changes beyond integrating the provided HTML.
+
+## Scope & Assumptions
+- Replace `/` route with static HTML file in `public`.
+- Update CTA buttons (`Generate my first list`) to link to `/chat`.
+- Assume existing chat route at `/chat` remains unchanged.
+
+## Approach
+- Move `landing.html` to `public/landingpage.html`.
+- Replace `app/page.tsx` with a redirect to `/landingpage.html`.
+- Convert CTA buttons to anchor tags targeting `/chat`.
+
+## Impacted Areas
+- `app/page.tsx`.
+- `public/landingpage.html`.
+
+## Risks & Mitigations
+- **Risk:** Static HTML may bypass Next.js layout styling.
+  - *Mitigation:* Keep page self‑contained with its own styles.
+- **Risk:** Redirect loop if file missing.
+  - *Mitigation:* Ensure `landingpage.html` committed under `public/`.
+
+## Validation
+- Run linting and Playwright tests (`pnpm lint`, `pnpm test`).
+- Manually verify landing page loads and CTA links to `/chat`.
+
+## Rollout/Rollback
+- Rollout: deploy updated build.
+- Rollback: revert commit to restore previous landing page.
+
+## Links
+- PR: (TBD)

--- a/public/landingpage.html
+++ b/public/landingpage.html
@@ -181,12 +181,12 @@ animation: countUp 0.8s ease-out forwards;
                                 .icon-box svg { width: 20px; height: 20px; stroke: currentColor; }
                             </style>
                         
-                            <button class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
+                            <a href="/chat" class="glow-btn" style="--x: 147.5882568359375px; --y: 32.68756103515625px;">
                             <span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
                             </span>
                             Generate my first list
-                          </button>
+                          </a>
                         
                             <script>
                                 const btn = document.querySelector('.glow-btn');
@@ -778,9 +778,9 @@ animation: countUp 0.8s ease-out forwards;
                     Describe who you need. Cerch AI returns verified, deduped, enriched, and scored results. Export, API, and alerts included.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <button class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
+                    <a href="/chat" class="glow-btn" style="--x: 37.5882568359375px; --y: 19.68756103515625px;">Generate my first list<span class="icon-box">
                               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="arrow-right" class="lucide lucide-arrow-right w-[24px] h-[24px]" data-icon-replaced="true" style="width: 24px; height: 24px; color: rgb(17, 24, 39);"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
-                            </span></button>
+                            </span></a>
                     <button class="px-8 py-4 border border-white/30 rounded-full font-semibold hover:bg-white/10 transition-all flex items-center gap-2 justify-center">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" data-lucide="phone" class="lucide lucide-phone h-5 w-5"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"></path></svg>
                         Schedule a Call


### PR DESCRIPTION
## Summary
- redirect `/` to new animated `landingpage.html`
- link landing page call-to-action buttons to chat
- document landing page replacement PRD

## Testing
- `pnpm lint` *(fails: Do not shadow the global "escape" property; Forbidden non-null assertion; Static Elements should not be interactive)*
- `pnpm test` *(fails: This module cannot be imported from a Client Component module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc75106e48324bfd8907e77d028d3